### PR TITLE
feat: Re-add the comments and make the PR message more generic

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -61,17 +61,3 @@ impl Default for ValidationConfig {
         }
     }
 }
-
-pub fn review_message_prefix_from_values(
-    is_title_conventional: bool,
-    has_work_item: bool,
-) -> String {
-    match (is_title_conventional, has_work_item) {
-        (true, true) => "<!-- MERGE_WARDEN_VALID -->".to_string(),
-        (true, false) => "<!-- MERGE_WARDEN_MISSING_WORK_ITEM -->".to_string(),
-        (false, true) => "<!-- MERGE_WARDEN_TITLE_IS_NOT_CONVENTIONAL -->".to_string(),
-        (false, false) => {
-            "<!-- MERGE_WARDEN_TITLE_IS_NOT_CONVENTIONAL_MISSING_WORK_ITEM -->".to_string()
-        }
-    }
-}

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -112,12 +112,10 @@ impl PullRequestProvider for MockGitProvider {
 
     async fn update_pr_blocking_review(
         &self,
-        repo_owner: &str,
-        repo_name: &str,
-        pr_number: u64,
-        message: &str,
-        message_prefix: &str,
-        is_approved: bool,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _pr_number: u64,
+        _is_approved: bool,
     ) -> Result<(), Error> {
         unimplemented!("Not needed for this test")
     }
@@ -193,12 +191,10 @@ impl PullRequestProvider for ErrorMockGitProvider {
 
     async fn update_pr_blocking_review(
         &self,
-        repo_owner: &str,
-        repo_name: &str,
-        pr_number: u64,
-        message: &str,
-        message_prefix: &str,
-        is_approved: bool,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _pr_number: u64,
+        _is_approved: bool,
     ) -> Result<(), Error> {
         unimplemented!("Not needed for this test")
     }
@@ -400,7 +396,7 @@ async fn test_determine_labels_invalid_type_in_pr_title() {
         .await
         .unwrap();
     assert!(
-        labels.len() == 0,
+        labels.is_empty(),
         "Expected no labels for title with a missing type"
     );
 }
@@ -448,7 +444,7 @@ async fn test_determine_labels_missing_type_in_pr_title() {
     let labels = set_pull_request_labels(&provider, "owner", "repo", &pr)
         .await
         .unwrap();
-    assert!(labels.len() == 0, "Expected no labels for missing type");
+    assert!(labels.is_empty(), "Expected no labels for missing type");
 }
 
 #[test]

--- a/crates/developer_platforms/src/lib.rs
+++ b/crates/developer_platforms/src/lib.rs
@@ -46,7 +46,7 @@ use models::{Comment, Label, PullRequest};
 ///     # async fn add_labels(&self, _: &str, _: &str, _: u64, _: &[String]) -> Result<(), Error> { unimplemented!() }
 ///     # async fn remove_label(&self, _: &str, _: &str, _: u64, _: &str) -> Result<(), Error> { unimplemented!() }
 ///     # async fn list_labels(&self, _: &str, _: &str, _: u64) -> Result<Vec<Label>, Error> { unimplemented!() }
-///     # async fn update_pr_blocking_review(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: bool) -> Result<(), Error> { unimplemented!() }
+///     # async fn update_pr_blocking_review(&self, _: &str, _: &str, _: u64, _: bool) -> Result<(), Error> { unimplemented!() }
 /// }
 /// ```
 #[async_trait]
@@ -192,7 +192,6 @@ pub trait PullRequestProvider {
     /// * `repo_owner` - The owner of the repository.
     /// * `repo_name` - The name of the repository.
     /// * `pr_number` - The pull request number.
-    /// * `message` - The review message that is applied.
     /// * `is_approved` - Whether the PR should be approved or 'rejected'.
     ///
     /// # Returns
@@ -203,8 +202,6 @@ pub trait PullRequestProvider {
         repo_owner: &str,
         repo_name: &str,
         pr_number: u64,
-        message: &str,
-        message_prefix: &str,
         is_approved: bool,
     ) -> Result<(), Error>;
 }


### PR DESCRIPTION
## Description

Re-added the ability for the application to add comments to a PR as well as remove those comments. This was done because we can remove comments but we can't remove a PR review message. So if we use comments to describe the exact problem, then we can remove those comments when the problems are fixed. This way we leave a minimal footprint.

Fixes #40

## Testing

Testing was done on the bot-test repository with a number of PRs.