### PR TITLE
fix(ops): Read GitHub App key from file in Terraform apply

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,7 @@ jobs:
         ARM_USE_OIDC: true
 
     - name: Create GitHub App Key File
-      run: echo "${{ secrets.GH_APP_PRIVATE_KEY }}" > ops/azure/gh_app_key.pem
+      run: printf '%s\n' "${{ secrets.GH_APP_PRIVATE_KEY }}" > ops/azure/gh_app_key.pem
       shell: bash # Explicitly use bash for redirection
 
     - name: Terraform Apply


### PR DESCRIPTION
## Description

Modify Terraform config (variables.tf, main.tf) to use file() function with a path variable for the GitHub App private key. Update deploy workflow to write the key secret to a temporary file, pass the path to terraform apply, and clean up the file afterwards. Use printf instead of echo for robustness.