### PR TITLE
ci: Fix the branch target for the publishing of the release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
     types:
       - closed
     branches:
-      - 'release/*' # Only run for branches matching release/*
+      - 'master' # Only run for pull requests targeting the master branch
 
 permissions:
   contents: write # To push tags and to create GitHub Releases


### PR DESCRIPTION
## Description

The publish-release workflow isn't being triggered
