### PR TITLE
ci: Run publish release with different account

### DIFF
--- a/.github/scripts/prepare-release.js
+++ b/.github/scripts/prepare-release.js
@@ -153,7 +153,12 @@ async function main() {
       }
       // Delete the remote branch
       console.log(`[INFO] Deleting stale remote branch ${branch.name}...`);
-      await githubRest(`/repos/${OWNER}/${REPO}/git/refs/heads/${branch.name}`, 'DELETE');
+      try {
+        await githubRest(`/repos/${OWNER}/${REPO}/git/refs/heads/${branch.name}`, 'DELETE');
+        console.log(`[INFO] Successfully deleted branch ${branch.name}.`);
+      } catch (error) {
+        console.error(`[ERROR] Failed to delete branch ${branch.name}:`, error.message || error);
+      }
     }
   }
   // 1. Get the default branch name (e.g., "main" or "master")

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Configure Git user
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "releaser[bot]"
+          git config user.email "releaser[bot]@users.noreply.github.com"
 
       - name: Calculate next version
         id: calc_version
@@ -82,6 +82,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - name: Set up git remote to use app token
+        if: steps.generate_changelog.outputs.has_notes == 'true'
+        run: |
+          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
 
       - name: Prepare release with verified commit and PR
         if: steps.generate_changelog.outputs.has_notes == 'true'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,6 +18,13 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, 'chore(release):') }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -26,6 +33,8 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
 
       - name: Install cargo binstall
         uses: cargo-bins/cargo-binstall@main
@@ -52,48 +61,6 @@ jobs:
           echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_OUTPUT
           echo "The next version is: ${NEXT_VERSION}"
 
-      - name: Handle stale release branches
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          NEXT_VERSION="${{ steps.calc_version.outputs.NEXT_VERSION }}"
-          echo "Next calculated version: ${NEXT_VERSION}"
-          # List all remote release branches
-          git fetch origin 'refs/heads/release/*:refs/remotes/origin/release/*'
-          for branch in $(git branch -r --list 'origin/release/*' | sed 's|origin/||'); do
-            # Extract version from branch name (e.g., release/1.2.3 -> 1.2.3)
-            branch_version=$(echo "$branch" | sed 's|release/||')
-            echo "Found existing release branch: ${branch} (version: ${branch_version})"
-
-            if [[ "$branch_version" != "$NEXT_VERSION" ]]; then
-              echo "Branch ${branch} is stale (version ${branch_version} != ${NEXT_VERSION}). Cleaning up..."
-              # Find PR associated with the stale branch
-              PR_NUMBER=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
-              if [[ -n "$PR_NUMBER" ]]; then
-                echo "Closing PR #${PR_NUMBER} for stale branch ${branch}..."
-                gh pr close "$PR_NUMBER" --comment "Closing stale release PR as version ${NEXT_VERSION} is now being prepared."
-              else
-                echo "No open PR found for stale branch ${branch}."
-              fi
-              # Delete the stale remote branch
-              echo "Deleting stale remote branch ${branch}..."
-              git push origin --delete "$branch"
-            fi
-          done
-
-      - name: Check if release branch already exists
-        id: check_branch
-        run: |
-          NEXT_VERSION="${{ steps.calc_version.outputs.NEXT_VERSION }}"
-          BRANCH_NAME="release/${NEXT_VERSION}"
-          if git rev-parse --verify --quiet "origin/${BRANCH_NAME}"; then
-            echo "Branch ${BRANCH_NAME} already exists."
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "Branch ${BRANCH_NAME} does not exist."
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Generate Changelog Section
         id: generate_changelog
         run: |
@@ -115,14 +82,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Generate GitHub App token
-        if: steps.generate_changelog.outputs.has_notes == 'true'
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Prepare release with verified commit and PR
         if: steps.generate_changelog.outputs.has_notes == 'true'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -29,6 +36,8 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
 
       - name: Install cargo binstall
         uses: cargo-bins/cargo-binstall@main
@@ -45,8 +54,8 @@ jobs:
       # Recommended as per: https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token
       - name: Configure Git user
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "releaser[bot]"
+          git config user.email "releaser[bot]@users.noreply.github.com"
 
       - name: Get release version from Cargo.toml
         id: get_version
@@ -54,6 +63,10 @@ jobs:
           RELEASE_VERSION=$(conventional_commits_next_version --from-commit-hash $(git rev-parse $(git describe --tags --abbrev=0)) --from-version $(git describe --tags --abbrev=0) --calculation-mode "Batch")
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
           echo "The release version is: ${RELEASE_VERSION}"
+
+      - name: Set up git remote to use app token
+        run: |
+          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
 
       - name: Create and Push Git Tag
         run: |
@@ -75,7 +88,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           RELEASE_VERSION="${{ steps.get_version.outputs.RELEASE_VERSION }}"
           echo "Creating GitHub Release for ${RELEASE_VERSION}"


### PR DESCRIPTION
## Description

Run the release scripts with the releaser app identity so that when we merge the release PR and create the release we trigger the deploy scripts.