### PR TITLE
fix: Set the workspace_id for the AppInsights workspace

### DIFF
--- a/.github/scripts/update_github_label_colors.ps1
+++ b/.github/scripts/update_github_label_colors.ps1
@@ -1,0 +1,79 @@
+# PowerShell script to update GitHub label colors for pvandervelde/RepoRoller
+# Requires: GitHub CLI (gh) installed and authenticated
+# Colors chosen from ColorBrewer/Colorblind-safe palettes for accessibility
+
+# Label definitions: Name, Color, Description
+$labelUpdates = @(
+    @{ Name = "type: feat"; Color = "fcc37b"; Description = "New feature or enhancement" }
+    @{ Name = "type: fix"; Color = "fcc37b"; Description = "Bug fix" }
+    @{ Name = "type: chore"; Color = "fcc37b"; Description = "Chore or maintenance task" }
+    @{ Name = "type: docs"; Color = "fcc37b"; Description = "Documentation changes" }
+    @{ Name = "type: refactor"; Color = "fcc37b"; Description = "Code refactoring" }
+    @{ Name = "type: test"; Color = "fcc37b"; Description = "Test-related changes" }
+    @{ Name = "type: ci"; Color = "fcc37b"; Description = "Continuous integration or build changes" }
+
+    @{ Name = "status: needs-triage"; Color = "64befb"; Description = "Needs triage or review" }
+    @{ Name = "status: in-progress"; Color = "64befb"; Description = "Work in progress" }
+    @{ Name = "status: needs-review"; Color = "64befb"; Description = "Needs code or design review" }
+    @{ Name = "status: blocked"; Color = "64befb"; Description = "Blocked by another issue or dependency" }
+    @{ Name = "status: completed"; Color = "64befb"; Description = "Work completed" }
+
+    @{ Name = "prio: high"; Color = "e94648"; Description = "High priority" }
+    @{ Name = "prio: medium"; Color = "e94648"; Description = "Medium priority" }
+    @{ Name = "prio: low"; Color = "e94648"; Description = "Low priority" }
+
+    @{ Name = "comp: core"; Color = "91c764"; Description = "Core component" }
+    @{ Name = "comp: github"; Color = "91c764"; Description = "GitHub integration/component" }
+    @{ Name = "comp: azure"; Color = "91c764"; Description = "Azure integration/component" }
+    @{ Name = "comp: infra"; Color = "91c764"; Description = "Infrastructure component" }
+    @{ Name = "comp: ci"; Color = "91c764"; Description = "CI/CD component" }
+
+    @{ Name = "size: XS"; Color = "fecc3e"; Description = "Extra small change" }
+    @{ Name = "size: S"; Color = "fecc3e"; Description = "Small change" }
+    @{ Name = "size: M"; Color = "fecc3e"; Description = "Medium change" }
+    @{ Name = "size: L"; Color = "fecc3e"; Description = "Large change" }
+    @{ Name = "size: XL"; Color = "fecc3e"; Description = "Extra large change" }
+
+    @{ Name = "feedback: discussion"; Color = "c8367a"; Description = "Discussion or open feedback" }
+    @{ Name = "feedback: rfc"; Color = "c8367a"; Description = "Request for comments (RFC)" }
+    @{ Name = "feedback: question"; Color = "c8367a"; Description = "General question or inquiry" }
+
+    @{ Name = "inactive: duplicate"; Color = "d3d8de"; Description = "Duplicate issue or PR" }
+    @{ Name = "inactive: wontfix"; Color = "d3d8de"; Description = "Will not fix" }
+    @{ Name = "inactive: by-design"; Color = "d3d8de"; Description = "Closed as by design" }
+)
+
+# Get all current labels in the repo
+$currentLabels = gh label list | ForEach-Object {
+    # Each line: "label-name    color    description"
+    ($_ -split "`t")[0].Trim()
+}
+
+# Build a hashtable of label names for quick lookup
+$labelNames = $labelUpdates | ForEach-Object { $_.Name }
+
+# Update or create labels as needed
+foreach ($label in $labelUpdates)
+{
+    $name = $label.Name
+    $color = $label.Color
+    $desc = $label.Description
+    if ($currentLabels -contains $name)
+    {
+        Write-Host "Updating label '$name' to color #$color and description '$desc'"
+        gh label edit "$name" --color $color --description "$desc"
+    }
+    else
+    {
+        Write-Host "Creating label '$name' with color #$color and description '$desc'"
+        gh label create "$name" --color $color --description "$desc"
+    }
+}
+
+# Remove labels not in the hashtable
+$labelsToRemove = $currentLabels | Where-Object { -not ($labelNames -contains $_) }
+foreach ($label in $labelsToRemove)
+{
+    Write-Host "Deleting label '$label' (not in hashtable)"
+    gh label delete "$label" --yes
+}

--- a/ops/azure/main.tf
+++ b/ops/azure/main.tf
@@ -218,7 +218,7 @@ resource "azurerm_application_insights" "appinsights" {
   # to set it to the value that Azure gave it. Otherwise terraform will try to set it to null,
   # which will result in an error.
   # see: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights#workspace_id-1
-  workspace_id = "35762962-e84b-4078-a9ca-efdb7928dfa0"
+  workspace_id = "/subscriptions/c3420a9b-5638-4c5e-9f3a-b54263bd3662/resourceGroups/ai_p-aue-tf-mergew-insights_0f848fbd-11b2-44f3-8eea-4dccb8585e69_managed/providers/Microsoft.OperationalInsights/workspaces/managed-p-aue-tf-mergew-insights-ws"
 
   tags = merge(
     local.common_tags,

--- a/ops/azure/main.tf
+++ b/ops/azure/main.tf
@@ -214,6 +214,11 @@ resource "azurerm_application_insights" "appinsights" {
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
   application_type    = "web"
+  # Once set the workspace_id cannot be changed. Given that we didn't originally set it, we need
+  # to set it to the value that Azure gave it. Otherwise terraform will try to set it to null,
+  # which will result in an error.
+  # see: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights#workspace_id-1
+  workspace_id = "35762962-e84b-4078-a9ca-efdb7928dfa0"
 
   tags = merge(
     local.common_tags,


### PR DESCRIPTION
## Description

The `workspace_id` for AppInsights wasn't specified in the terraform code but it was set by Azure. Once set a `workspace_id` cannot be changed, so we are setting it to what Azure has defined the `workspace_id` to be.

Fixes #108 

## Testing

The build will run a `terraform plan` but the actual test won't be until we try to deploy it.

