### PR TITLE
fix(azure-functions): use ManagedIdentityCredential for Key Vault access in Azure Functions

### DIFF
--- a/crates/azure-functions/src/main.rs
+++ b/crates/azure-functions/src/main.rs
@@ -208,7 +208,13 @@ async fn get_secret_from_keyvault(
     secret_name: &str,
 ) -> Result<String, AzureFunctionsError> {
     // Use ManagedIdentityCredential for Azure Functions in production
-    let credential = azure_identity::ManagedIdentityCredential::default();
+    let credential = azure_identity::ManagedIdentityCredential::new(None).map_err(|e| {
+        error!(
+            error = e.to_string(),
+            "Failed create the managed credential."
+        );
+        AzureFunctionsError::AuthError("Failed to create the managed credential.".to_string())
+    })?;
     let client = SecretClient::new(key_vault_url, credential, None).map_err(|e| {
         error!(
             error = e.to_string(),

--- a/crates/azure-functions/src/main.rs
+++ b/crates/azure-functions/src/main.rs
@@ -211,7 +211,7 @@ async fn get_secret_from_keyvault(
     let credential = azure_identity::ManagedIdentityCredential::new(None).map_err(|e| {
         error!(
             error = e.to_string(),
-            "Failed create the managed credential."
+            "Failed to create the managed credential."
         );
         AzureFunctionsError::AuthError("Failed to create the managed credential.".to_string())
     })?;

--- a/crates/azure-functions/src/main.rs
+++ b/crates/azure-functions/src/main.rs
@@ -207,13 +207,8 @@ async fn get_secret_from_keyvault(
     key_vault_url: &str,
     secret_name: &str,
 ) -> Result<String, AzureFunctionsError> {
-    let credential = azure_identity::DefaultAzureCredential::new().map_err(|e| {
-        error!(
-            error = e.to_string(),
-            "Failed to create an Azure Identity credential."
-        );
-        AzureFunctionsError::AuthError("Failed to create an Azure Identity credential.".to_string())
-    })?;
+    // Use ManagedIdentityCredential for Azure Functions in production
+    let credential = azure_identity::ManagedIdentityCredential::default();
     let client = SecretClient::new(key_vault_url, credential, None).map_err(|e| {
         error!(
             error = e.to_string(),


### PR DESCRIPTION
## Description

Switch from DefaultAzureCredential to ManagedIdentityCredential for production authentication. This enables secure, secretless access to Key Vault using the function app's managed identity.

fixes #113

## Testing

This cannot be tested until it is deployed
