### PR TITLE
fix(azure-functions): bridge log crate events to tracing for Application Insights

### DIFF
--- a/crates/azure-functions/Cargo.toml
+++ b/crates/azure-functions/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-opentelemetry = { workspace = true, features = ["thiserror"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+tracing-log = "0.2"
 
 # See https://github.com/sfackler/rust-openssl/issues/1627
 # and https://docs.rs/openssl/latest/openssl/#vendored

--- a/crates/azure-functions/Cargo.toml
+++ b/crates/azure-functions/Cargo.toml
@@ -18,7 +18,7 @@ hmac.workspace = true
 octocrab = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
-opentelemetry-application-insights = "0.40.0"
+opentelemetry-application-insights = { version = "0.40.0", features = ["reqwest", "tracing"] }
 opentelemetry-otlp = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
@@ -30,6 +30,8 @@ tracing = { workspace = true, features = ["log"] }
 tracing-opentelemetry = { workspace = true, features = ["thiserror"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tracing-log = "0.2"
+log = "0.4.27"
+opentelemetry-appender-log = "0.29.0"
 
 # See https://github.com/sfackler/rust-openssl/issues/1627
 # and https://docs.rs/openssl/latest/openssl/#vendored

--- a/crates/azure-functions/src/telemetry.rs
+++ b/crates/azure-functions/src/telemetry.rs
@@ -41,6 +41,9 @@ pub async fn init_telemetry(
     // Create a tracing layer with the configured tracer
     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
 
+    // Bridge log crate events to tracing
+    tracing_log::LogTracer::init().expect("Failed to set log tracer");
+
     // Use the tracing subscriber `Registry`, or any other subscriber
     // that impls `LookupSpan`
     tracing_subscriber::registry()

--- a/crates/azure-functions/src/telemetry.rs
+++ b/crates/azure-functions/src/telemetry.rs
@@ -1,25 +1,42 @@
+use log::Level;
+use opentelemetry::global;
 use opentelemetry::trace::TracerProvider;
+use opentelemetry_appender_log::OpenTelemetryLogBridge;
+use opentelemetry_application_insights::Exporter;
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::metrics::PeriodicReader;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::BatchConfigBuilder;
 use opentelemetry_sdk::trace::BatchSpanProcessor;
 use opentelemetry_sdk::Resource;
+use reqwest::Client;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
 use crate::errors::AzureFunctionsError;
 
-pub async fn init_telemetry(
-    app_insights_connection_string: &str,
-) -> Result<(), AzureFunctionsError> {
-    // Set up Azure Monitor exporter
-    let azure_monitor_exporter =
-        opentelemetry_application_insights::Exporter::new_from_connection_string(
-            app_insights_connection_string,
-            reqwest::Client::new(),
-        )
-        .expect("valid connection string");
+fn init_logs(exporter: Exporter<Client>) -> Result<(), AzureFunctionsError> {
+    let logger_provider = SdkLoggerProvider::builder()
+        .with_batch_exporter(exporter)
+        .build();
+    let otel_log_appender = OpenTelemetryLogBridge::new(&logger_provider);
+    log::set_boxed_logger(Box::new(otel_log_appender)).unwrap();
+    log::set_max_level(Level::Trace.to_level_filter());
 
+    Ok(())
+}
+
+fn init_metrics(exporter: Exporter<Client>) -> Result<(), AzureFunctionsError> {
+    let reader = PeriodicReader::builder(exporter).build();
+    let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+    global::set_meter_provider(meter_provider.clone());
+
+    Ok(())
+}
+
+fn init_tracing(azure_monitor_exporter: Exporter<Client>) -> Result<(), AzureFunctionsError> {
     // Create a BatchSpanProcessor for each exporter
-    let azure_monitor_processor = BatchSpanProcessor::builder(azure_monitor_exporter)
+    let azure_monitor_processor = BatchSpanProcessor::builder(azure_monitor_exporter.clone())
         .with_batch_config(
             BatchConfigBuilder::default()
                 .with_max_queue_size(4096)
@@ -35,6 +52,7 @@ pub async fn init_telemetry(
         .with_resource(resource)
         .with_span_processor(azure_monitor_processor)
         .build();
+    global::set_tracer_provider(provider.clone());
 
     let tracer = provider.tracer("merge_warden");
 
@@ -50,6 +68,24 @@ pub async fn init_telemetry(
         .with(telemetry)
         .with(EnvFilter::from_default_env())
         .init();
+
+    Ok(())
+}
+
+pub async fn init_telemetry(
+    app_insights_connection_string: &str,
+) -> Result<(), AzureFunctionsError> {
+    // Set up Azure Monitor exporter
+    let azure_monitor_exporter =
+        opentelemetry_application_insights::Exporter::new_from_connection_string(
+            app_insights_connection_string,
+            reqwest::Client::new(),
+        )
+        .expect("valid connection string");
+
+    init_logs(azure_monitor_exporter.clone())?;
+    init_metrics(azure_monitor_exporter.clone())?;
+    init_tracing(azure_monitor_exporter)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

The Azure Functions crate was not forwarding logs from dependencies using the standard \log\ crate macros to Application Insights. This was because \	racing_log::LogTracer::init()\ was not called, so only logs emitted via the \	racing\ macros were exported.

## Solution

- Add \	racing_log::LogTracer::init()\ to the telemetry initialization to bridge \log\ crate events into the \	racing\ ecosystem.
- This ensures all logs, including those from dependencies, are captured and exported to Application Insights.

references #116