### PR TITLE
fix: correct conventional_commits_next_version command arguments

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -59,7 +59,7 @@ jobs:
           # Use Conventional Commits Next Version to calculate the next version
           LAST_TAG=$(git describe --tags --abbrev=0)
           LAST_COMMIT=$(git rev-parse ${LAST_TAG})
-          NEXT_VERSION=$(conventional_commits_next_version --from-commit-hash ${LAST_COMMIT} --from-version ${LAST_TAG} --calculation-mode "Batch")
+          NEXT_VERSION=$(conventional_commits_next_version --from-version ${LAST_TAG} --calculation-mode Batch ${LAST_COMMIT})
           echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_OUTPUT
           echo "The next version is: ${NEXT_VERSION}"
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0)
           LAST_COMMIT=$(git rev-parse ${LAST_TAG})
-          RELEASE_VERSION=$(conventional_commits_next_version --from-commit-hash ${LAST_COMMIT} --from-version ${LAST_TAG} --calculation-mode "Batch")
+          RELEASE_VERSION=$(conventional_commits_next_version --from-version ${LAST_TAG} --calculation-mode Batch ${LAST_COMMIT})
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
           echo "The release version is: ${RELEASE_VERSION}"
 


### PR DESCRIPTION
- Remove invalid --from-commit-hash flag
- Pass commit hash as positional argument
- Remove quotes from calculation-mode value
- Fixes deployment failure in publish-release and prepare-release workflows
