### PR TITLE
fix(release): update Dockerfile base image and add version assertion to publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -68,9 +68,10 @@ jobs:
           echo "The release version is: ${RELEASE_VERSION}"
 
       - name: Assert calculated version matches release branch
+        env:
+          RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
+          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          RELEASE_VERSION="${{ steps.get_version.outputs.RELEASE_VERSION }}"
-          BRANCH_REF="${{ github.event.pull_request.head.ref }}"
           BRANCH_VERSION="${BRANCH_REF#release/}"
           if [[ "${RELEASE_VERSION}" != "${BRANCH_VERSION}" ]]; then
             echo "ERROR: Calculated version (${RELEASE_VERSION}) does not match branch version (${BRANCH_VERSION})"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -67,6 +67,19 @@ jobs:
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
           echo "The release version is: ${RELEASE_VERSION}"
 
+      - name: Assert calculated version matches release branch
+        run: |
+          RELEASE_VERSION="${{ steps.get_version.outputs.RELEASE_VERSION }}"
+          BRANCH_REF="${{ github.event.pull_request.head.ref }}"
+          BRANCH_VERSION="${BRANCH_REF#release/}"
+          if [[ "${RELEASE_VERSION}" != "${BRANCH_VERSION}" ]]; then
+            echo "ERROR: Calculated version (${RELEASE_VERSION}) does not match branch version (${BRANCH_VERSION})"
+            echo "Branch: ${BRANCH_REF}"
+            echo "This usually means commits made after the release branch was cut have changed the calculated version."
+            exit 1
+          fi
+          echo "Version assertion passed: ${RELEASE_VERSION} matches branch ${BRANCH_REF}"
+
       - name: Set up git remote to use app token
         run: |
           git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"

--- a/crates/server/Dockerfile
+++ b/crates/server/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage: compile the release binary.
-FROM rust:1.90-slim@sha256:7fa728f3678acf5980d5db70960cf8491aff9411976789086676bdf0c19db39e AS builder
+# Digest pinned to rust:1.94-slim (multi-arch manifest list). Renovate keeps this current.
+FROM rust:1.94-slim@sha256:48150eec4f1e854ec689c7ca4c16d35193c4ea19dde13b6df515192707229ff8 AS builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release -p merge_warden_server

--- a/docs/spec/design/containerisation.md
+++ b/docs/spec/design/containerisation.md
@@ -161,7 +161,7 @@ Single-stage build (or multi-stage with builder + distroless/scratch runtime):
 
 ```dockerfile
 # Build stage
-FROM rust:1.90-slim AS builder
+FROM rust:1.94-slim AS builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release -p merge_warden_server


### PR DESCRIPTION
Updates the server Dockerfile builder image from the stale rust:1.90-slim to rust:1.94-slim, and adds a version assertion step to the publish-release workflow to prevent silent tag mismatches.

## What Changed
- `crates/server/Dockerfile`: builder stage updated from `rust:1.90-slim` (pinned to an outdated digest) to `rust:1.94-slim` with the current multi-arch manifest list digest. The distroless runtime image digest is unchanged. A comment has been added to clarify that Renovate manages digest freshness.
- `.github/workflows/publish-release.yml`: a new "Assert calculated version matches release branch" step added between version calculation and tag creation. The step extracts the version from the release branch name (`release/<version>`) and fails with a diagnostic error message if it does not match the version produced by `conventional_commits_next_version`.

## Why
The Dockerfile was pinning `rust:1.90-slim` with a stale digest — the current stable Rust toolchain is 1.94. Continuing to use 1.90 meant the builder was running on an outdated toolchain without receiving security or correctness fixes.

The publish-release workflow recalculates the version at merge time using `conventional_commits_next_version --calculation-mode Batch`. If any commits landed on `master` after the release branch was cut, the recalculated version could silently differ from the version encoded in the `release/<version>` branch name — creating a git tag and GitHub Release with an unexpected version number. The assertion step makes this failure loud and early.

## How
The builder image version was updated in-place with the latest multi-arch manifest list digest retrieved via the Docker Hub registry API. Renovate (`config:best-practices`) is already configured to open automated PRs when this digest goes stale.

The version assertion step in `publish-release.yml` strips the `release/` prefix from `github.event.pull_request.head.ref` to get the expected version, then compares it to the `RELEASE_VERSION` output of the existing calculation step. A mismatch exits 1 with a clear, actionable error message before any tag is created.

## Testing Evidence
- **Test Coverage:** No automated tests apply — these are workflow and Dockerfile changes. The assertion step itself serves as a runtime guard.
- **Test Results:** N/A — CI workflow changes are validated at run time.
- **Manual Testing:** Digest for `rust:1.94-slim` verified via Docker Hub registry API (`sha256:48150eec...`). Distroless digest confirmed unchanged. The assertion logic was validated manually by tracing the branch-name extraction (`${BRANCH_REF#release/}`) against representative branch names.

## Reviewer Guidance
- Verify the `rust:1.94-slim` digest `sha256:48150eec4f1e854ec689c7ca4c16d35193c4ea19dde13b6df515192707229ff8` is the correct multi-arch manifest list digest for the current 1.94-slim tag.
- Confirm the version assertion step is positioned correctly — it must run after `steps.get_version` and before `Create and Push Git Tag`.
- Check that the `deploy.yml` `publish-cli` job is unaffected — it is triggered by `release: published` and does not depend on these workflow steps.