### PR TITLE
fix(release): update release branch to master HEAD on each workflow run/crea

### DIFF
--- a/.github/scripts/prepare-release.js
+++ b/.github/scripts/prepare-release.js
@@ -189,14 +189,26 @@ async function main() {
   const baseCommitOid = branchInfo.data.repository.ref.target.oid;
   console.log(`[INFO] Latest commit OID on ${DEFAULT_BRANCH}: ${baseCommitOid}`);
 
-  // 3. Check if the release branch exists
+  // 3. Ensure the release branch exists and is up to date with the default branch.
+  // If the branch already exists we force-update it so that any new commits that have
+  // landed on the default branch since the last workflow run are incorporated (i.e. the
+  // branch is effectively rebased onto master's HEAD before we add the release commit).
   let branchExists = false;
   try {
     await githubRest(`/repos/${OWNER}/${REPO}/git/refs/heads/${BRANCH_NAME}`);
     branchExists = true;
-    console.log(`[INFO] Release branch "${BRANCH_NAME}" already exists.`);
   } catch {
     branchExists = false;
+  }
+
+  if (branchExists) {
+    console.log(`[INFO] Release branch "${BRANCH_NAME}" already exists. Updating it to ${DEFAULT_BRANCH} HEAD (${baseCommitOid})...`);
+    await githubRest(`/repos/${OWNER}/${REPO}/git/refs/heads/${BRANCH_NAME}`, 'PATCH', {
+      sha: baseCommitOid,
+      force: true
+    });
+    console.log(`[INFO] Updated release branch "${BRANCH_NAME}" to ${DEFAULT_BRANCH} (${baseCommitOid}).`);
+  } else {
     console.log(`[INFO] Release branch "${BRANCH_NAME}" does not exist. Will create it.`);
     // Branch does not exist, create it from the default branch's latest commit
     await githubRest(`/repos/${OWNER}/${REPO}/git/refs`, 'POST', {
@@ -218,12 +230,9 @@ async function main() {
     }
   `, { owner: OWNER, repo: REPO, head: BRANCH_NAME });
 
-  if (branchExists && prs.data.repository.pullRequests.nodes.length > 0) {
-    // Both branch and PR exist, do not proceed
-    console.log(`[INFO] Both release branch "${BRANCH_NAME}" and an open PR already exist.`);
-    console.log(`[INFO] Existing PR: ${prs.data.repository.pullRequests.nodes[0].url}`);
-    console.log(`[INFO] Exiting without making changes.`);
-    return;
+  if (prs.data.repository.pullRequests.nodes.length > 0) {
+    console.log(`[INFO] An open PR already exists for "${BRANCH_NAME}": ${prs.data.repository.pullRequests.nodes[0].url}`);
+    console.log(`[INFO] Will still update the branch content with the latest changelog and version.`);
   }
 
   // 5. Prepare updated file contents for CHANGELOG.md and Cargo.toml

--- a/.github/scripts/prepare-release.js
+++ b/.github/scripts/prepare-release.js
@@ -96,6 +96,7 @@ function githubGraphQL(query, variables) {
  */
 function githubRest(path, method = 'GET', body = null) {
   return new Promise((resolve, reject) => {
+    const bodyData = body ? JSON.stringify(body) : null;
     const options = {
       hostname: 'api.github.com',
       path,
@@ -103,7 +104,8 @@ function githubRest(path, method = 'GET', body = null) {
       headers: {
         'Authorization': `bearer ${GH_TOKEN}`,
         'User-Agent': 'prepare-release-script',
-        'Accept': 'application/vnd.github+json'
+        'Accept': 'application/vnd.github+json',
+        ...(bodyData ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(bodyData) } : {})
       }
     };
     const req = https.request(options, res => {
@@ -118,7 +120,7 @@ function githubRest(path, method = 'GET', body = null) {
       });
     });
     req.on('error', reject);
-    if (body) req.write(JSON.stringify(body));
+    if (bodyData) req.write(bodyData);
     req.end();
   });
 }
@@ -193,12 +195,15 @@ async function main() {
   // If the branch already exists we force-update it so that any new commits that have
   // landed on the default branch since the last workflow run are incorporated (i.e. the
   // branch is effectively rebased onto master's HEAD before we add the release commit).
+  // NOTE: Force-resetting the branch and adding a new commit will dismiss any existing
+  // approvals on an open release PR. This is intentional — the PR content changes on
+  // every push to master and must be re-reviewed.
   let branchExists = false;
   try {
     await githubRest(`/repos/${OWNER}/${REPO}/git/refs/heads/${BRANCH_NAME}`);
     branchExists = true;
   } catch {
-    branchExists = false;
+    // Branch does not exist; branchExists remains false.
   }
 
   if (branchExists) {
@@ -399,6 +404,9 @@ async function main() {
 
 // Entry point: run main() and handle errors
 main().catch(err => {
-  console.error(err);
+  console.error('[ERROR] Script failed:', err.message || err);
+  if ((err.message || '').includes('expectedHeadOid')) {
+    console.error('[HINT] The "expectedHeadOid" conflict usually means a concurrent workflow run updated the branch first. Re-running the workflow should succeed.');
+  }
   process.exit(1);
 });


### PR DESCRIPTION
Fixes the prepare-release script so the release branch and its PR are fully refreshed on every push to master, not just when first created.

## What Changed
- The existing release branch ref is now force-updated (`PATCH /git/refs` with `force: true`) to master's latest commit before changelog and `Cargo.toml` changes are written.
- The early `return` that aborted execution when both the release branch and its PR already existed has been removed. An existing PR is now just logged and execution continues.

## Why
The script was designed around two implicit assumptions that turned out to be wrong:

1. When the release branch already existed it was left untouched, so it stayed pointed at the commit it was first created from. New commits merged to master were never incorporated.
2. The guard `if (branchExists && PR exists) { return; }` meant every workflow run after the very first one was a silent no-op — no branch update, no changelog regeneration, no version bump.

## How
Step 3 now separates the existence check (`GET /git/refs`) from the update logic. If the branch exists it issues a `PATCH` to force-reset the ref; if it does not exist it issues the original `POST` to create it. The PR-exists check in step 4 is kept purely for informational logging and no longer gates the rest of the script.

## Testing Evidence
- **Test Coverage:** No automated tests exist for this script; changes are verified by the `test-prepare-release-script.yml` workflow which can be triggered via `workflow_dispatch`.
- **Test Results:** Logic traced manually against the script flow for both the "branch exists + PR exists" path and the "branch does not exist" path.
- **Manual Testing:** Not yet run against the live repository.

## Reviewer Guidance
- Verify the `PATCH /git/refs/heads/<branch>` call with `force: true` is acceptable given that the release branch should only ever contain the prepare-release commit on top of master — a force-reset is safe here but worth confirming.
- Confirm there are no race conditions if the workflow fires twice in quick succession (the `expectedHeadOid` used in the GraphQL commit mutation provides optimistic concurrency protection for the commit step itself).
- No breaking changes; behaviour is additive — branches that were previously silently skipped will now be updated.