### PR TITLE
feat(core): add structured PR title diagnostics with actionable error messages

### DIFF
--- a/crates/core/src/check_tests.rs
+++ b/crates/core/src/check_tests.rs
@@ -1625,7 +1625,56 @@ fn should_detect_leading_whitespace_and_uppercase_type_together() {
     assert_eq!(diagnosis.suggested_fix.as_deref(), Some("feat: add login"));
 }
 
-// ── diagnose_pr_title: 3.11 Valid title ───────────────────────────────────
+// ── diagnose_pr_title: 3.11 Compound UppercaseType + MissingColon ─────────
+// Regression: MissingColon must be reported even when UppercaseType is also present.
+
+#[test]
+fn should_detect_uppercase_type_and_missing_colon_together() {
+    let diagnosis = diagnose_pr_title("FEAT add login");
+    assert_eq!(
+        diagnosis.issues,
+        vec![
+            TitleIssue::UppercaseType {
+                found: "FEAT".to_string()
+            },
+            TitleIssue::MissingColon,
+        ],
+        "Expected [UppercaseType, MissingColon], got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(
+        diagnosis.suggested_fix.as_deref(),
+        Some("feat: add login"),
+        "Expected suggested_fix to insert lowercase type and colon"
+    );
+}
+
+// ── diagnose_pr_title: 3.12 Compound UnrecognizedType + MissingColon ──────
+// Regression: MissingColon must be reported even when UnrecognizedType is also present.
+
+#[test]
+fn should_detect_unrecognized_type_and_missing_colon_together() {
+    let diagnosis = diagnose_pr_title("feature add login");
+    assert_eq!(
+        diagnosis.issues,
+        vec![
+            TitleIssue::UnrecognizedType {
+                found: "feature".to_string(),
+                nearest_valid: Some("feat".to_string()),
+            },
+            TitleIssue::MissingColon,
+        ],
+        "Expected [UnrecognizedType, MissingColon], got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(
+        diagnosis.suggested_fix.as_deref(),
+        Some("feat: add login"),
+        "Expected suggested_fix to correct typo-type and insert colon"
+    );
+}
+
+// ── diagnose_pr_title: 3.13 Valid title ───────────────────────────────────
 
 #[test]
 fn should_return_empty_issues_and_no_fix_for_valid_conventional_title() {

--- a/crates/core/src/check_tests.rs
+++ b/crates/core/src/check_tests.rs
@@ -7,13 +7,15 @@ use merge_warden_developer_platforms::models::{PullRequest, User};
 
 use crate::{
     checks::{
-        check_pr_title, check_work_item_reference, extract_closing_issue_reference, IssueReference,
+        check_pr_title, check_work_item_reference, diagnose_pr_title,
+        extract_closing_issue_reference, IssueReference, TitleDiagnosis, TitleIssue,
+        TitleValidationResult,
     },
     config::{
         BypassRule, CurrentPullRequestValidationConfiguration, CONVENTIONAL_COMMIT_REGEX,
         WORK_ITEM_REGEX,
     },
-    validation_result::BypassRuleType,
+    validation_result::{BypassInfo, BypassRuleType, ValidationResult},
 };
 
 // Helper functions for creating test data
@@ -1160,4 +1162,532 @@ fn issue_number_accessor_returns_correct_number_for_cross_repo() {
         issue_number: 456,
     };
     assert_eq!(reference.issue_number(), 456);
+}
+
+// ── TitleIssue construction tests ──────────────────────────────────────────
+
+#[test]
+fn should_construct_title_issue_empty_description() {
+    let issue = TitleIssue::EmptyDescription;
+    assert_eq!(issue, TitleIssue::EmptyDescription);
+}
+
+#[test]
+fn should_construct_title_issue_invalid_scope() {
+    let issue = TitleIssue::InvalidScope {
+        scope: "Auth".to_string(),
+    };
+    assert!(matches!(issue, TitleIssue::InvalidScope { scope } if scope == "Auth"));
+}
+
+#[test]
+fn should_construct_title_issue_leading_whitespace() {
+    let issue = TitleIssue::LeadingWhitespace;
+    assert_eq!(issue, TitleIssue::LeadingWhitespace);
+}
+
+#[test]
+fn should_construct_title_issue_missing_colon() {
+    let issue = TitleIssue::MissingColon;
+    assert_eq!(issue, TitleIssue::MissingColon);
+}
+
+#[test]
+fn should_construct_title_issue_missing_space_after_colon() {
+    let issue = TitleIssue::MissingSpaceAfterColon;
+    assert_eq!(issue, TitleIssue::MissingSpaceAfterColon);
+}
+
+#[test]
+fn should_construct_title_issue_no_type_prefix() {
+    let issue = TitleIssue::NoTypePrefix;
+    assert_eq!(issue, TitleIssue::NoTypePrefix);
+}
+
+#[test]
+fn should_construct_title_issue_unrecognized_type_with_nearest_valid() {
+    let issue = TitleIssue::UnrecognizedType {
+        found: "feature".to_string(),
+        nearest_valid: Some("feat".to_string()),
+    };
+    assert!(
+        matches!(issue, TitleIssue::UnrecognizedType { ref found, ref nearest_valid }
+            if found == "feature" && nearest_valid.as_deref() == Some("feat"))
+    );
+}
+
+#[test]
+fn should_construct_title_issue_unrecognized_type_without_nearest_valid() {
+    let issue = TitleIssue::UnrecognizedType {
+        found: "xyz".to_string(),
+        nearest_valid: None,
+    };
+    assert!(
+        matches!(issue, TitleIssue::UnrecognizedType { ref found, ref nearest_valid }
+            if found == "xyz" && nearest_valid.is_none())
+    );
+}
+
+#[test]
+fn should_construct_title_issue_uppercase_type() {
+    let issue = TitleIssue::UppercaseType {
+        found: "FEAT".to_string(),
+    };
+    assert!(matches!(issue, TitleIssue::UppercaseType { found } if found == "FEAT"));
+}
+
+#[test]
+fn should_construct_title_issue_whitespace_before_colon() {
+    let issue = TitleIssue::WhitespaceBeforeColon {
+        found: "feat ".to_string(),
+    };
+    assert!(matches!(issue, TitleIssue::WhitespaceBeforeColon { found } if found == "feat "));
+}
+
+// ── TitleDiagnosis construction tests ──────────────────────────────────────
+
+#[test]
+fn should_construct_title_diagnosis_with_single_issue_and_fix() {
+    let diagnosis = TitleDiagnosis {
+        issues: vec![TitleIssue::UppercaseType {
+            found: "FEAT".to_string(),
+        }],
+        suggested_fix: Some("feat: add login".to_string()),
+    };
+    assert_eq!(diagnosis.issues.len(), 1);
+    assert_eq!(diagnosis.suggested_fix.as_deref(), Some("feat: add login"));
+}
+
+#[test]
+fn should_construct_title_diagnosis_with_multiple_issues_and_no_fix() {
+    let diagnosis = TitleDiagnosis {
+        issues: vec![TitleIssue::NoTypePrefix, TitleIssue::EmptyDescription],
+        suggested_fix: None,
+    };
+    assert_eq!(diagnosis.issues.len(), 2);
+    assert!(diagnosis.suggested_fix.is_none());
+}
+
+#[test]
+fn should_construct_title_diagnosis_with_no_issues() {
+    let diagnosis = TitleDiagnosis {
+        issues: vec![],
+        suggested_fix: None,
+    };
+    assert!(diagnosis.issues.is_empty());
+    assert!(diagnosis.suggested_fix.is_none());
+}
+
+// ── TitleValidationResult construction and delegation tests ────────────────
+
+#[test]
+fn should_construct_title_validation_result_valid_no_diagnosis() {
+    let result = TitleValidationResult {
+        validation: ValidationResult::valid(),
+        diagnosis: None,
+    };
+    assert!(result.is_valid());
+    assert!(!result.was_bypassed());
+    assert!(result.bypass_info().is_none());
+    assert!(result.diagnosis.is_none());
+}
+
+#[test]
+fn should_construct_title_validation_result_invalid_with_diagnosis() {
+    let diagnosis = TitleDiagnosis {
+        issues: vec![TitleIssue::NoTypePrefix],
+        suggested_fix: None,
+    };
+    let result = TitleValidationResult {
+        validation: ValidationResult::invalid(),
+        diagnosis: Some(diagnosis),
+    };
+    assert!(!result.is_valid());
+    assert!(!result.was_bypassed());
+    assert!(result.bypass_info().is_none());
+    assert!(result.diagnosis.is_some());
+}
+
+#[test]
+fn should_construct_title_validation_result_bypassed_no_diagnosis() {
+    let bypass_info = BypassInfo {
+        rule_type: BypassRuleType::TitleConvention,
+        user: "release-bot".to_string(),
+    };
+    let result = TitleValidationResult {
+        validation: ValidationResult::bypassed(bypass_info.clone()),
+        diagnosis: None,
+    };
+    assert!(result.is_valid());
+    assert!(result.was_bypassed());
+    assert_eq!(result.bypass_info(), Some(&bypass_info));
+    assert!(result.diagnosis.is_none());
+}
+
+// ── diagnose_pr_title: 3.1 LeadingWhitespace ──────────────────────────────
+
+#[test]
+fn should_detect_leading_whitespace_and_suggest_trim() {
+    let diagnosis = diagnose_pr_title(" feat: add login");
+    assert!(
+        diagnosis.issues.contains(&TitleIssue::LeadingWhitespace),
+        "Expected LeadingWhitespace in issues: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(
+        diagnosis.suggested_fix.as_deref(),
+        Some("feat: add login"),
+        "Expected trimmed title as suggested_fix"
+    );
+}
+
+#[test]
+fn should_detect_leading_whitespace_only_once_even_with_multiple_spaces() {
+    let diagnosis = diagnose_pr_title("   feat: add login");
+    assert_eq!(
+        diagnosis
+            .issues
+            .iter()
+            .filter(|i| **i == TitleIssue::LeadingWhitespace)
+            .count(),
+        1,
+        "LeadingWhitespace should appear exactly once"
+    );
+    assert_eq!(diagnosis.suggested_fix.as_deref(), Some("feat: add login"));
+}
+
+// ── diagnose_pr_title: 3.2 WhitespaceBeforeColon ──────────────────────────
+
+#[test]
+fn should_detect_whitespace_before_colon_with_no_scope() {
+    let diagnosis = diagnose_pr_title("feat : add login");
+    assert!(
+        diagnosis
+            .issues
+            .iter()
+            .any(|i| matches!(i, TitleIssue::WhitespaceBeforeColon { found } if found == "feat ")),
+        "Expected WhitespaceBeforeColon {{ found: \"feat \" }}, got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(diagnosis.suggested_fix.as_deref(), Some("feat: add login"));
+}
+
+#[test]
+fn should_detect_whitespace_before_colon_with_scope() {
+    let diagnosis = diagnose_pr_title("feat(auth) : add login");
+    assert!(
+        diagnosis.issues.iter().any(
+            |i| matches!(i, TitleIssue::WhitespaceBeforeColon { found } if found == "feat(auth) ")
+        ),
+        "Expected WhitespaceBeforeColon {{ found: \"feat(auth) \" }}, got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(
+        diagnosis.suggested_fix.as_deref(),
+        Some("feat(auth): add login")
+    );
+}
+
+// ── diagnose_pr_title: 3.3 UppercaseType ──────────────────────────────────
+
+#[test]
+fn should_detect_fully_uppercase_type() {
+    let diagnosis = diagnose_pr_title("FEAT: add login");
+    assert!(
+        diagnosis
+            .issues
+            .iter()
+            .any(|i| matches!(i, TitleIssue::UppercaseType { found } if found == "FEAT")),
+        "Expected UppercaseType {{ found: \"FEAT\" }}, got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(diagnosis.suggested_fix.as_deref(), Some("feat: add login"));
+}
+
+#[test]
+fn should_detect_mixed_case_type() {
+    let diagnosis = diagnose_pr_title("Fix: bug in auth");
+    assert!(
+        diagnosis
+            .issues
+            .iter()
+            .any(|i| matches!(i, TitleIssue::UppercaseType { found } if found == "Fix")),
+        "Expected UppercaseType {{ found: \"Fix\" }}, got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(diagnosis.suggested_fix.as_deref(), Some("fix: bug in auth"));
+}
+
+// ── diagnose_pr_title: 3.4 UnrecognizedType ───────────────────────────────
+
+#[test]
+fn should_detect_unrecognized_type_for_each_typo_map_entry() {
+    let cases: &[(&str, &str, &str)] = &[
+        ("bug: fix crash", "bug", "fix"),
+        ("bugfix: fix crash", "bugfix", "fix"),
+        ("dep: update packages", "dep", "chore"),
+        ("dependencies: update packages", "dependencies", "chore"),
+        ("enhancement: add feature", "enhancement", "feat"),
+        ("feature: add login", "feature", "feat"),
+        ("hotfix: urgent patch", "hotfix", "fix"),
+    ];
+
+    for (title, typo, correct) in cases {
+        let diagnosis = diagnose_pr_title(title);
+        assert!(
+            diagnosis.issues.iter().any(|i| matches!(i,
+                TitleIssue::UnrecognizedType { found, nearest_valid: Some(nv) }
+                if found == typo && nv == correct
+            )),
+            "Title '{}': expected UnrecognizedType {{ found: {:?}, nearest_valid: Some({:?}) }}, got: {:?}",
+            title, typo, correct, diagnosis.issues
+        );
+        // suggested_fix should replace the typo token with the correction
+        let expected_fix = title.replacen(typo, correct, 1);
+        assert_eq!(
+            diagnosis.suggested_fix.as_deref(),
+            Some(expected_fix.as_str()),
+            "Title '{}': expected suggested_fix = {:?}",
+            title,
+            expected_fix
+        );
+    }
+}
+
+#[test]
+fn should_detect_unrecognized_type_with_no_nearest_valid_and_no_suggested_fix() {
+    let diagnosis = diagnose_pr_title("xyz: add login");
+    assert!(
+        diagnosis.issues.iter().any(|i| matches!(i,
+            TitleIssue::UnrecognizedType { found, nearest_valid: None }
+            if found == "xyz"
+        )),
+        "Expected UnrecognizedType {{ found: \"xyz\", nearest_valid: None }}, got: {:?}",
+        diagnosis.issues
+    );
+    assert!(
+        diagnosis.suggested_fix.is_none(),
+        "Expected no suggested_fix for unknown type, got: {:?}",
+        diagnosis.suggested_fix
+    );
+}
+
+// ── diagnose_pr_title: 3.5 MissingColon ───────────────────────────────────
+
+#[test]
+fn should_detect_missing_colon_and_suggest_insertion() {
+    let diagnosis = diagnose_pr_title("feat add login");
+    assert!(
+        diagnosis.issues.contains(&TitleIssue::MissingColon),
+        "Expected MissingColon, got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(diagnosis.suggested_fix.as_deref(), Some("feat: add login"));
+}
+
+// ── diagnose_pr_title: 3.6 MissingSpaceAfterColon ─────────────────────────
+
+#[test]
+fn should_detect_missing_space_after_colon_and_suggest_insertion() {
+    let diagnosis = diagnose_pr_title("feat:add login");
+    assert!(
+        diagnosis
+            .issues
+            .contains(&TitleIssue::MissingSpaceAfterColon),
+        "Expected MissingSpaceAfterColon, got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(diagnosis.suggested_fix.as_deref(), Some("feat: add login"));
+}
+
+// ── diagnose_pr_title: 3.7 EmptyDescription ───────────────────────────────
+
+#[test]
+fn should_detect_empty_description_with_trailing_space() {
+    let diagnosis = diagnose_pr_title("feat: ");
+    assert!(
+        diagnosis.issues.contains(&TitleIssue::EmptyDescription),
+        "Expected EmptyDescription, got: {:?}",
+        diagnosis.issues
+    );
+    assert!(
+        diagnosis.suggested_fix.is_none(),
+        "Expected no suggested_fix for EmptyDescription"
+    );
+}
+
+#[test]
+fn should_detect_empty_description_with_multiple_trailing_spaces() {
+    let diagnosis = diagnose_pr_title("feat:  ");
+    assert!(
+        diagnosis.issues.contains(&TitleIssue::EmptyDescription),
+        "Expected EmptyDescription, got: {:?}",
+        diagnosis.issues
+    );
+    assert!(diagnosis.suggested_fix.is_none());
+}
+
+// ── diagnose_pr_title: 3.8 InvalidScope ───────────────────────────────────
+
+#[test]
+fn should_detect_uppercase_chars_in_scope_and_suggest_lowercase() {
+    let diagnosis = diagnose_pr_title("feat(Auth): add login");
+    assert!(
+        diagnosis
+            .issues
+            .iter()
+            .any(|i| matches!(i, TitleIssue::InvalidScope { scope } if scope == "Auth")),
+        "Expected InvalidScope {{ scope: \"Auth\" }}, got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(
+        diagnosis.suggested_fix.as_deref(),
+        Some("feat(auth): add login")
+    );
+}
+
+#[test]
+fn should_detect_space_in_scope_and_suggest_hyphen_replacement() {
+    let diagnosis = diagnose_pr_title("feat(user service): add user");
+    assert!(
+        diagnosis
+            .issues
+            .iter()
+            .any(|i| matches!(i, TitleIssue::InvalidScope { scope } if scope == "user service")),
+        "Expected InvalidScope {{ scope: \"user service\" }}, got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(
+        diagnosis.suggested_fix.as_deref(),
+        Some("feat(user-service): add user")
+    );
+}
+
+// ── diagnose_pr_title: 3.9 NoTypePrefix ───────────────────────────────────
+
+#[test]
+fn should_detect_no_type_prefix_for_plain_sentence() {
+    let diagnosis = diagnose_pr_title("Add login functionality");
+    assert!(
+        diagnosis.issues.contains(&TitleIssue::NoTypePrefix),
+        "Expected NoTypePrefix for plain sentence, got: {:?}",
+        diagnosis.issues
+    );
+    assert!(
+        diagnosis.suggested_fix.is_none(),
+        "Expected no suggested_fix for NoTypePrefix"
+    );
+}
+
+#[test]
+fn should_detect_no_type_prefix_for_empty_string() {
+    let diagnosis = diagnose_pr_title("");
+    assert!(
+        diagnosis.issues.contains(&TitleIssue::NoTypePrefix),
+        "Expected NoTypePrefix for empty string, got: {:?}",
+        diagnosis.issues
+    );
+    assert!(diagnosis.suggested_fix.is_none());
+}
+
+#[test]
+fn should_detect_no_type_prefix_for_whitespace_only_string() {
+    let diagnosis = diagnose_pr_title("   ");
+    assert!(
+        diagnosis.issues.contains(&TitleIssue::LeadingWhitespace),
+        "Expected LeadingWhitespace for whitespace-only string, got: {:?}",
+        diagnosis.issues
+    );
+    assert!(
+        diagnosis.issues.contains(&TitleIssue::NoTypePrefix),
+        "Expected NoTypePrefix for whitespace-only string, got: {:?}",
+        diagnosis.issues
+    );
+    assert!(diagnosis.suggested_fix.is_none());
+}
+
+// ── diagnose_pr_title: 3.10 Compound case ─────────────────────────────────
+
+#[test]
+fn should_detect_leading_whitespace_and_uppercase_type_together() {
+    let diagnosis = diagnose_pr_title(" FEAT: add login");
+    assert_eq!(
+        diagnosis.issues,
+        vec![
+            TitleIssue::LeadingWhitespace,
+            TitleIssue::UppercaseType {
+                found: "FEAT".to_string()
+            }
+        ],
+        "Expected [LeadingWhitespace, UppercaseType], got: {:?}",
+        diagnosis.issues
+    );
+    assert_eq!(diagnosis.suggested_fix.as_deref(), Some("feat: add login"));
+}
+
+// ── diagnose_pr_title: 3.11 Valid title ───────────────────────────────────
+
+#[test]
+fn should_return_empty_issues_and_no_fix_for_valid_conventional_title() {
+    let diagnosis = diagnose_pr_title("feat: add login");
+    // diagnose_pr_title is called only for invalid titles, but a conforming title
+    // should produce an empty issues list (no problems found).
+    assert!(
+        diagnosis.issues.is_empty(),
+        "Expected no issues for valid title, got: {:?}",
+        diagnosis.issues
+    );
+    assert!(
+        diagnosis.suggested_fix.is_none(),
+        "Expected no suggested_fix for valid title"
+    );
+}
+
+// ── check_pr_title: 3.12 – 3.14 ───────────────────────────────────────────
+
+#[test]
+fn should_return_diagnosis_some_when_check_pr_title_with_invalid_title() {
+    let pr = create_pull_request(1, "invalid title format", None, None);
+    let bypass_rule = create_bypass_rule_disabled();
+    let config = create_default_config();
+
+    let result = check_pr_title(&pr, &bypass_rule, &config);
+
+    assert!(!result.is_valid(), "Expected invalid result for bad title");
+    assert!(
+        result.diagnosis.is_some(),
+        "Expected Some(diagnosis) for invalid title"
+    );
+}
+
+#[test]
+fn should_return_diagnosis_none_when_check_pr_title_with_valid_title() {
+    let pr = create_pull_request(1, "feat: add new login feature", None, None);
+    let bypass_rule = create_bypass_rule_disabled();
+    let config = create_default_config();
+
+    let result = check_pr_title(&pr, &bypass_rule, &config);
+
+    assert!(result.is_valid(), "Expected valid result for good title");
+    assert!(
+        result.diagnosis.is_none(),
+        "Expected None diagnosis for valid title"
+    );
+}
+
+#[test]
+fn should_return_diagnosis_none_when_check_pr_title_with_bypassed_user() {
+    let user = create_user(123, "release-bot");
+    let pr = create_pull_request(1, "invalid title format", None, Some(user));
+    let bypass_rule = create_bypass_rule_enabled_for_users(vec!["release-bot"]);
+    let config = create_default_config();
+
+    let result = check_pr_title(&pr, &bypass_rule, &config);
+
+    assert!(result.is_valid(), "Expected bypassed result to be valid");
+    assert!(result.was_bypassed(), "Expected bypass to have been used");
+    assert!(
+        result.diagnosis.is_none(),
+        "Expected None diagnosis when bypassed"
+    );
 }

--- a/crates/core/src/checks.rs
+++ b/crates/core/src/checks.rs
@@ -10,12 +10,13 @@
 //! and can be merged.
 
 use crate::{
-    config::{BypassRule, CurrentPullRequestValidationConfiguration},
+    config::{BypassRule, CurrentPullRequestValidationConfiguration, VALID_PR_TYPES},
     size::PrSizeInfo,
     validation_result::{BypassInfo, BypassRuleType, ValidationResult},
 };
 use merge_warden_developer_platforms::models::{PullRequest, PullRequestFile, User};
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 
 /// Compiled once at first use. Handles all four supported closing-keyword formats:
@@ -92,6 +93,594 @@ impl IssueReference {
     }
 }
 
+/// A structured diagnosis of why a PR title failed conventional-commit validation.
+///
+/// Contains the list of specific issues detected in the title and, when possible,
+/// a best-effort corrected title string.
+///
+/// `issues` may contain multiple entries when several problems are observed
+/// simultaneously (e.g. [`TitleIssue::LeadingWhitespace`] and
+/// [`TitleIssue::UppercaseType`] on `" FEAT: add login"`).
+///
+/// `suggested_fix` is `None` when no actionable correction can be inferred,
+/// for example when [`TitleIssue::NoTypePrefix`] or [`TitleIssue::EmptyDescription`]
+/// is reported.
+///
+/// # Examples
+///
+/// ```
+/// use merge_warden_core::checks::{TitleDiagnosis, TitleIssue};
+///
+/// let diagnosis = TitleDiagnosis {
+///     issues: vec![TitleIssue::UppercaseType { found: "FEAT".to_string() }],
+///     suggested_fix: Some("feat: add login".to_string()),
+/// };
+/// assert_eq!(diagnosis.issues.len(), 1);
+/// assert!(diagnosis.suggested_fix.is_some());
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TitleDiagnosis {
+    /// The specific issues detected in the PR title.
+    ///
+    /// May contain multiple entries when several problems are present simultaneously.
+    pub issues: Vec<TitleIssue>,
+
+    /// A best-effort corrected title string, or `None` when no fix can be inferred.
+    pub suggested_fix: Option<String>,
+}
+
+/// The result of validating a PR title, combining the validation outcome with
+/// an optional structured diagnosis.
+///
+/// This type is returned by [`check_pr_title`] and `MergeWarden::check_title`.
+/// It replaces the plain [`crate::validation_result::ValidationResult`] for title
+/// checks so that call sites can surface actionable feedback to PR authors.
+///
+/// `diagnosis` is:
+/// - `Some` when the title is **invalid** and not bypassed — contains the specific issues
+/// - `None` when the title is valid, or when validation was bypassed
+///
+/// The delegation methods [`is_valid`], [`was_bypassed`], and [`bypass_info`] forward
+/// to the inner [`crate::validation_result::ValidationResult`] so that existing call
+/// sites in `lib.rs` do not need to change.
+///
+/// # Examples
+///
+/// ```
+/// use merge_warden_core::checks::TitleValidationResult;
+/// use merge_warden_core::validation_result::ValidationResult;
+///
+/// let result = TitleValidationResult {
+///     validation: ValidationResult::valid(),
+///     diagnosis: None,
+/// };
+/// assert!(result.is_valid());
+/// assert!(!result.was_bypassed());
+/// assert!(result.bypass_info().is_none());
+/// ```
+///
+/// [`is_valid`]: TitleValidationResult::is_valid
+/// [`was_bypassed`]: TitleValidationResult::was_bypassed
+/// [`bypass_info`]: TitleValidationResult::bypass_info
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TitleValidationResult {
+    /// The underlying validation outcome (valid, invalid, or bypassed).
+    pub validation: ValidationResult,
+
+    /// Structured diagnosis, present only when the title is invalid and not bypassed.
+    pub diagnosis: Option<TitleDiagnosis>,
+}
+
+impl TitleValidationResult {
+    /// Returns `true` if validation passed (either valid content or bypassed).
+    ///
+    /// Delegates to [`ValidationResult::is_valid`][crate::validation_result::ValidationResult::is_valid].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use merge_warden_core::checks::TitleValidationResult;
+    /// use merge_warden_core::validation_result::ValidationResult;
+    ///
+    /// let result = TitleValidationResult { validation: ValidationResult::valid(), diagnosis: None };
+    /// assert!(result.is_valid());
+    /// ```
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.validation.is_valid()
+    }
+
+    /// Returns `true` if validation passed due to a bypass rule.
+    ///
+    /// Delegates to [`ValidationResult::was_bypassed`][crate::validation_result::ValidationResult::was_bypassed].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use merge_warden_core::checks::TitleValidationResult;
+    /// use merge_warden_core::validation_result::{BypassInfo, BypassRuleType, ValidationResult};
+    ///
+    /// let bypass_info = BypassInfo {
+    ///     rule_type: BypassRuleType::TitleConvention,
+    ///     user: "release-bot".to_string(),
+    /// };
+    /// let result = TitleValidationResult {
+    ///     validation: ValidationResult::bypassed(bypass_info),
+    ///     diagnosis: None,
+    /// };
+    /// assert!(result.was_bypassed());
+    /// ```
+    #[must_use]
+    pub fn was_bypassed(&self) -> bool {
+        self.validation.was_bypassed()
+    }
+
+    /// Returns the bypass information if a bypass was used, or `None` otherwise.
+    ///
+    /// Delegates to [`ValidationResult::bypass_info`][crate::validation_result::ValidationResult::bypass_info].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use merge_warden_core::checks::TitleValidationResult;
+    /// use merge_warden_core::validation_result::{BypassInfo, BypassRuleType, ValidationResult};
+    ///
+    /// let bypass_info = BypassInfo {
+    ///     rule_type: BypassRuleType::TitleConvention,
+    ///     user: "release-bot".to_string(),
+    /// };
+    /// let result = TitleValidationResult {
+    ///     validation: ValidationResult::bypassed(bypass_info.clone()),
+    ///     diagnosis: None,
+    /// };
+    /// assert_eq!(result.bypass_info(), Some(&bypass_info));
+    /// ```
+    #[must_use]
+    pub fn bypass_info(&self) -> Option<&BypassInfo> {
+        self.validation.bypass_info()
+    }
+}
+
+/// A specific issue found in a PR title that explains why the title does not conform
+/// to the Conventional Commits format.
+///
+/// Each variant carries the data needed to produce a specific human-readable message
+/// and, in many cases, a suggested corrected title.
+///
+/// Several variants can apply simultaneously; for example a title of `" FEAT: add login"`
+/// produces both [`LeadingWhitespace`][TitleIssue::LeadingWhitespace] and
+/// [`UppercaseType`][TitleIssue::UppercaseType].
+///
+/// # Examples
+///
+/// ```
+/// use merge_warden_core::checks::TitleIssue;
+///
+/// let issue = TitleIssue::UppercaseType { found: "FEAT".to_string() };
+/// assert!(matches!(issue, TitleIssue::UppercaseType { .. }));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TitleIssue {
+    /// The description portion of the title is absent or whitespace-only.
+    ///
+    /// Triggered when the title contains a valid type and colon (e.g. `"feat: "`)
+    /// but no non-whitespace description follows.  No `suggested_fix` is produced
+    /// because the user must supply meaningful content.
+    ///
+    /// # Examples
+    ///
+    /// - `"feat: "` — colon with trailing space only
+    /// - `"feat:  "` — colon with multiple trailing spaces
+    EmptyDescription,
+
+    /// The scope contains characters outside `[a-z0-9_-]`.
+    ///
+    /// The `suggested_fix` lowercases the scope and replaces spaces with `-`.
+    ///
+    /// # Examples
+    ///
+    /// - `"feat(Auth): add login"` — uppercase letters in scope
+    /// - `"feat(user service): x"` — space inside scope
+    InvalidScope {
+        /// The raw scope string as extracted from the title (without surrounding parentheses).
+        scope: String,
+    },
+
+    /// The title begins with one or more whitespace characters.
+    ///
+    /// Detection trims the title before applying all subsequent checks, so this
+    /// variant may appear alongside others such as [`UppercaseType`][TitleIssue::UppercaseType].
+    ///
+    /// # Examples
+    ///
+    /// - `" feat: add login"` — one leading space
+    LeadingWhitespace,
+
+    /// A recognised type is present but is not followed by `:`.
+    ///
+    /// The `suggested_fix` inserts `:` after the type token.
+    ///
+    /// # Examples
+    ///
+    /// - `"feat add login"` — type without colon separator
+    MissingColon,
+
+    /// The `:` separator is present but the character immediately after it is not a space.
+    ///
+    /// The `suggested_fix` inserts the missing space.
+    ///
+    /// # Examples
+    ///
+    /// - `"feat:add login"` — no space after colon
+    MissingSpaceAfterColon,
+
+    /// No recognisable type prefix was found at the start of the title.
+    ///
+    /// This is the fallback variant emitted when none of the other patterns match.
+    /// No `suggested_fix` is produced.
+    ///
+    /// # Examples
+    ///
+    /// - `"Add login functionality"` — plain sentence, no type prefix
+    /// - `""` — empty title
+    /// - `"   "` — whitespace-only title
+    NoTypePrefix,
+
+    /// The type token does not appear in the approved list and did not match a known synonym.
+    ///
+    /// `nearest_valid` is `Some` when the token is a known typo or synonym (e.g.
+    /// `"feature"` → `"feat"`), and `None` when the token is completely unrecognised.
+    /// When `nearest_valid` is `Some`, the `suggested_fix` replaces the token; otherwise
+    /// `suggested_fix` is `None`.
+    ///
+    /// # Examples
+    ///
+    /// - `"feature: add login"` → `found: "feature"`, `nearest_valid: Some("feat")`
+    /// - `"xyz: add login"` → `found: "xyz"`, `nearest_valid: None`
+    UnrecognizedType {
+        /// The unrecognised type token as extracted from the title.
+        found: String,
+        /// The nearest valid type from the approved list, if a known synonym mapping exists.
+        nearest_valid: Option<String>,
+    },
+
+    /// The type token is a correctly-spelled conventional commit type but is not lowercase.
+    ///
+    /// The `suggested_fix` lowercases the type token.
+    ///
+    /// # Examples
+    ///
+    /// - `"FEAT: add login"` → `found: "FEAT"`
+    /// - `"Fix: bug"` → `found: "Fix"`
+    UppercaseType {
+        /// The type token as it appears in the title (wrong case).
+        found: String,
+    },
+
+    /// There is whitespace between the type/scope token and the `:` separator.
+    ///
+    /// The `suggested_fix` removes the extra whitespace.
+    ///
+    /// # Examples
+    ///
+    /// - `"feat : add login"` — space before colon
+    /// - `"feat(auth) : add login"` — space before colon with scope present
+    WhitespaceBeforeColon {
+        /// The prefix (type + optional scope) including the trailing whitespace, as extracted.
+        found: String,
+    },
+}
+
+/// Common typo / synonym mappings from a known-wrong type word to the correct one.
+///
+/// Used by [`diagnose_pr_title`] to populate [`TitleIssue::UnrecognizedType::nearest_valid`]
+/// and to build `suggested_fix` strings.
+const TYPE_TYPO_MAP: &[(&str, &str)] = &[
+    ("bug", "fix"),
+    ("bugfix", "fix"),
+    ("dep", "chore"),
+    ("dependencies", "chore"),
+    ("enhancement", "feat"),
+    ("feature", "feat"),
+    ("hotfix", "fix"),
+];
+
+/// Analyses a PR title that is known to be invalid and returns a structured diagnosis
+/// describing every detected problem and, where possible, a suggested corrected title.
+///
+/// This is a pure function with no I/O or mutable state.  It is called by
+/// [`check_pr_title`] on the failure path.
+///
+/// Multiple [`TitleIssue`] entries may be returned simultaneously when the title
+/// exhibits several problems at once (e.g. leading whitespace **and** an uppercase type).
+/// Detection continues after each non-fatal check so that the caller receives a
+/// complete picture.
+///
+/// # Arguments
+///
+/// * `title` - The raw PR title string, exactly as received from the provider.
+///
+/// # Returns
+///
+/// A [`TitleDiagnosis`] containing the list of issues found and, when possible,
+/// a best-effort corrected title string.
+///
+/// # Examples
+///
+/// ```
+/// use merge_warden_core::checks::{diagnose_pr_title, TitleIssue};
+///
+/// let diagnosis = diagnose_pr_title(" FEAT: add login");
+/// assert!(diagnosis.issues.contains(&TitleIssue::LeadingWhitespace));
+/// assert!(diagnosis.issues.contains(&TitleIssue::UppercaseType { found: "FEAT".to_string() }));
+/// assert_eq!(diagnosis.suggested_fix.as_deref(), Some("feat: add login"));
+/// ```
+#[must_use]
+pub fn diagnose_pr_title(title: &str) -> TitleDiagnosis {
+    let mut issues: Vec<TitleIssue> = Vec::new();
+
+    // ── Step 1: Leading whitespace ────────────────────────────────────────────
+    let leading_ws = title.starts_with(|c: char| c.is_whitespace());
+    if leading_ws {
+        issues.push(TitleIssue::LeadingWhitespace);
+    }
+    // All subsequent work is performed on the trimmed title.
+    let working = title.trim();
+
+    // If the working string is empty after trimming, there is no prefix at all.
+    if working.is_empty() {
+        issues.push(TitleIssue::NoTypePrefix);
+        return TitleDiagnosis {
+            issues,
+            suggested_fix: None,
+        };
+    }
+
+    // ── Extract the candidate type token (chars before `(`, `!`, `:`, or space) ──
+    let token_end = working.find(['(', '!', ':', ' ']).unwrap_or(working.len());
+    let raw_token = &working[..token_end];
+
+    // ── Step 2: Whitespace before colon ──────────────────────────────────────
+    // Look for whitespace immediately before the first `:` in the prefix region
+    // (the part before the description, i.e. up to and including the colon).
+    let colon_pos = working.find(':');
+    if let Some(pos) = colon_pos {
+        if pos > 0 {
+            let char_before = working[..pos]
+                .chars()
+                .next_back()
+                .is_some_and(char::is_whitespace);
+            if char_before {
+                let prefix_with_space = &working[..pos];
+                issues.push(TitleIssue::WhitespaceBeforeColon {
+                    found: prefix_with_space.to_string(),
+                });
+            }
+        }
+    }
+
+    // ── Step 3 & 4: UnrecognizedType / UppercaseType ─────────────────────────
+    let token_lower = raw_token.to_lowercase();
+    let is_valid_exact = VALID_PR_TYPES.contains(&raw_token);
+    let is_valid_lower = VALID_PR_TYPES.contains(&token_lower.as_str());
+
+    // Track what we have already diagnosed about the type token so we can skip
+    // the MissingColon / MissingSpaceAfterColon checks when appropriate.
+    let mut type_token_diagnosed = false;
+
+    if !raw_token.is_empty() && !is_valid_exact {
+        if is_valid_lower {
+            // ── Step 4: Uppercase type ────────────────────────────────────────
+            issues.push(TitleIssue::UppercaseType {
+                found: raw_token.to_string(),
+            });
+            type_token_diagnosed = true;
+        } else {
+            // ── Step 3: Unrecognised type ─────────────────────────────────────
+            // Only diagnose as UnrecognizedType when there is a colon (indicating a
+            // conventional-commit attempt) or the token is a known synonym/typo.
+            // Otherwise the title is plain prose and will fall through to NoTypePrefix.
+            let nearest_valid = TYPE_TYPO_MAP
+                .iter()
+                .find(|(typo, _)| *typo == token_lower.as_str())
+                .map(|(_, correct)| (*correct).to_string());
+            if colon_pos.is_some() || nearest_valid.is_some() {
+                issues.push(TitleIssue::UnrecognizedType {
+                    found: raw_token.to_string(),
+                    nearest_valid,
+                });
+                type_token_diagnosed = true;
+            }
+        }
+    }
+
+    // ── Steps 5–8 only make sense when we have a potentially-valid type token ──
+    // (i.e. the token is valid lowercase, or we are past the UppercaseType branch)
+    let effective_token = if is_valid_lower || is_valid_exact {
+        Some(token_lower.as_str().to_string())
+    } else {
+        // Unrecognised type — look it up in the typo map to get a correctable form.
+        TYPE_TYPO_MAP
+            .iter()
+            .find(|(typo, _)| *typo == token_lower.as_str())
+            .map(|(_, correct)| (*correct).to_string())
+    };
+
+    if let Some(ref _eff_token) = effective_token {
+        check_scope(working, &mut issues);
+        check_colon_issues(working, colon_pos, type_token_diagnosed, &mut issues);
+    }
+
+    // ── Step 9: NoTypePrefix fallback ────────────────────────────────────────
+    // Only push NoTypePrefix when we genuinely could not identify any recognisable
+    // conventional-commit structure.  Guarding on `effective_token.is_none()` prevents
+    // valid titles (where `effective_token` is `Some`) from being misidentified as
+    // having no prefix just because they raised no issues.
+    if (issues.is_empty() && effective_token.is_none())
+        || (issues.len() == 1
+            && issues[0] == TitleIssue::LeadingWhitespace
+            && effective_token.is_none())
+    {
+        issues.push(TitleIssue::NoTypePrefix);
+        return TitleDiagnosis {
+            issues,
+            suggested_fix: None,
+        };
+    }
+
+    // ── Build suggested_fix ───────────────────────────────────────────────────
+    // If no issues were found, the title is valid and no fix is needed.
+    if issues.is_empty() {
+        return TitleDiagnosis {
+            issues,
+            suggested_fix: None,
+        };
+    }
+    let suggested_fix = build_suggested_fix(working, &issues);
+
+    TitleDiagnosis {
+        issues,
+        suggested_fix,
+    }
+}
+
+/// Checks for an invalid scope in the working title and appends [`TitleIssue::InvalidScope`]
+/// when found.
+///
+/// A scope is considered invalid when it contains characters outside `[a-z0-9_-]`.
+fn check_scope(working: &str, issues: &mut Vec<TitleIssue>) {
+    if let Some(scope_start) = working.find('(') {
+        let scope_end = working[scope_start..].find(')').map(|i| scope_start + i);
+        if let Some(end) = scope_end {
+            let scope_content = &working[scope_start + 1..end];
+            let scope_invalid = scope_content
+                .chars()
+                .any(|c| !matches!(c, 'a'..='z' | '0'..='9' | '_' | '-'));
+            if scope_invalid {
+                issues.push(TitleIssue::InvalidScope {
+                    scope: scope_content.to_string(),
+                });
+            }
+        }
+    }
+}
+
+/// Checks for missing-colon, missing-space-after-colon, and empty-description issues.
+///
+/// Appends the relevant [`TitleIssue`] variant(s) found in the working title.
+fn check_colon_issues(
+    working: &str,
+    colon_pos: Option<usize>,
+    type_token_diagnosed: bool,
+    issues: &mut Vec<TitleIssue>,
+) {
+    if colon_pos.is_none() && !type_token_diagnosed {
+        // ── Step 5: Missing colon ─────────────────────────────────────────────
+        issues.push(TitleIssue::MissingColon);
+    } else if let Some(colon) = colon_pos {
+        let after_colon = &working[colon + 1..];
+        if !after_colon.is_empty() && !after_colon.starts_with(' ') {
+            // ── Step 6: Missing space after colon ─────────────────────────────
+            issues.push(TitleIssue::MissingSpaceAfterColon);
+        } else if after_colon.trim().is_empty() {
+            // ── Step 7: Empty description ──────────────────────────────────────
+            issues.push(TitleIssue::EmptyDescription);
+        }
+    }
+}
+
+/// Constructs a best-effort corrected title from the working (trimmed) title and the
+/// list of issues that were diagnosed.
+///
+/// Returns `None` when the problems are unresolvable (e.g. `NoTypePrefix`,
+/// `EmptyDescription`).
+fn build_suggested_fix(working: &str, issues: &[TitleIssue]) -> Option<String> {
+    // Unresolvable issues: no fix possible.
+    // UnrecognizedType without a nearest_valid is also unresolvable — we don't know
+    // what type the author intended, so we cannot suggest a corrected title.
+    let unresolvable = issues.iter().any(|i| {
+        matches!(
+            i,
+            TitleIssue::NoTypePrefix
+                | TitleIssue::EmptyDescription
+                | TitleIssue::UnrecognizedType {
+                    nearest_valid: None,
+                    ..
+                }
+        )
+    });
+    if unresolvable {
+        return None;
+    }
+
+    let mut result = working.to_string();
+
+    // Apply corrections in reverse order of their lexical position so that
+    // index-based mutations don't invalidate later positions.
+
+    // Fix UppercaseType or UnrecognizedType — replace the type token at the start.
+    let token_end = result.find(['(', '!', ':', ' ']).unwrap_or(result.len());
+    let raw_token = result[..token_end].to_string();
+    let replacement_token: Option<String> = issues.iter().find_map(|i| match i {
+        TitleIssue::UppercaseType { found } => Some(found.to_lowercase()),
+        TitleIssue::UnrecognizedType { nearest_valid, .. } => nearest_valid.clone(),
+        _ => None,
+    });
+    if let Some(ref rep) = replacement_token {
+        result = format!("{}{}", rep, &result[token_end..]);
+    }
+
+    // Fix WhitespaceBeforeColon — remove whitespace directly before the colon.
+    if issues
+        .iter()
+        .any(|i| matches!(i, TitleIssue::WhitespaceBeforeColon { .. }))
+    {
+        // After possibly replacing the type token, find and strip whitespace before `:`.
+        if let Some(colon_pos) = result.find(':') {
+            let trimmed_prefix = result[..colon_pos].trim_end().to_string();
+            let after_colon = result[colon_pos..].to_string();
+            result = format!("{trimmed_prefix}{after_colon}");
+        }
+    }
+
+    // Fix InvalidScope — lowercase the scope and replace spaces with `-`.
+    if let Some(TitleIssue::InvalidScope { scope }) = issues
+        .iter()
+        .find(|i| matches!(i, TitleIssue::InvalidScope { .. }))
+    {
+        let fixed_scope = scope.to_lowercase().replace(' ', "-");
+        // Replace only the first occurrence of `(<scope>)` in the result.
+        let needle = format!("({scope})");
+        let replacement = format!("({fixed_scope})");
+        result = result.replacen(&needle, &replacement, 1);
+    }
+
+    // Fix MissingColon — insert `:` after the type token (and optional scope/!).
+    if issues.iter().any(|i| matches!(i, TitleIssue::MissingColon)) {
+        // Find the end of the type+scope+! prefix.
+        let prefix_end = result.find(' ').unwrap_or(result.len());
+        result = format!("{}:{}", &result[..prefix_end], &result[prefix_end..]);
+    }
+
+    // Fix MissingSpaceAfterColon — insert a space after the colon.
+    if issues
+        .iter()
+        .any(|i| matches!(i, TitleIssue::MissingSpaceAfterColon))
+    {
+        if let Some(colon_pos) = result.find(':') {
+            let after = &result[colon_pos + 1..];
+            if !after.starts_with(' ') {
+                result = format!("{}: {}", &result[..colon_pos], after);
+            }
+        }
+    }
+
+    // Replace the token string "Some(raw)"/None label note if replacements were
+    // performed; also guard against producing the same string as the original.
+    let _ = raw_token; // used implicitly above
+    Some(result)
+}
+
 /// Validates that the PR title follows the Conventional Commits format with bypass support.
 ///
 /// This function checks if the PR title follows the Conventional Commits format.
@@ -102,10 +691,14 @@ impl IssueReference {
 ///
 /// * `pr` - The pull request to validate
 /// * `bypass_rule` - The bypass rule for title validation
+/// * `current_configuration` - The current validation configuration
 ///
 /// # Returns
 ///
-/// A `ValidationResult` indicating whether the title is valid and any bypass information
+/// A [`TitleValidationResult`] whose `diagnosis` field is:
+/// - `None` when the title is valid or validation was bypassed
+/// - `Some` when the title is invalid, containing structured feedback and an optional
+///   suggested-fix string
 ///
 /// # Examples
 ///
@@ -114,7 +707,7 @@ impl IssueReference {
 /// use merge_warden_core::checks::check_pr_title;
 /// use merge_warden_core::config::{BypassRule, CurrentPullRequestValidationConfiguration};
 ///
-/// // Regular validation
+/// // Regular validation — valid title
 /// let pr = PullRequest {
 ///     number: 123,
 ///     title: "feat(auth): add GitHub login".to_string(),
@@ -124,16 +717,17 @@ impl IssueReference {
 ///     milestone_number: None,
 /// };
 ///
-/// let bypass_rule = BypassRule::default(); // Disabled bypass
+/// let bypass_rule = BypassRule::default();
 /// let config = CurrentPullRequestValidationConfiguration::default();
 /// let result = check_pr_title(&pr, &bypass_rule, &config);
 /// assert!(result.is_valid());
 /// assert!(!result.was_bypassed());
+/// assert!(result.diagnosis.is_none());
 ///
 /// // Bypass validation for authorized user with invalid title
 /// let pr_with_bad_title = PullRequest {
 ///     number: 124,
-///     title: "fix urgent bug".to_string(), // Invalid format
+///     title: "fix urgent bug".to_string(),
 ///     draft: false,
 ///     body: Some("Emergency fix".to_string()),
 ///     author: Some(User {
@@ -145,14 +739,16 @@ impl IssueReference {
 ///
 /// let bypass_rule = BypassRule::new(true, vec!["emergency-bot".to_string()]);
 /// let result = check_pr_title(&pr_with_bad_title, &bypass_rule, &config);
-/// assert!(result.is_valid()); // Bypass allows invalid title
+/// assert!(result.is_valid());
 /// assert!(result.was_bypassed());
+/// assert!(result.diagnosis.is_none());
 /// ```
+#[must_use]
 pub fn check_pr_title(
     pr: &PullRequest,
     bypass_rule: &BypassRule,
     current_configuration: &CurrentPullRequestValidationConfiguration,
-) -> ValidationResult {
+) -> TitleValidationResult {
     let user = pr.author.as_ref();
 
     // Check if user can bypass title validation
@@ -162,19 +758,34 @@ pub fn check_pr_title(
             user: user.unwrap().login.clone(), // Safe unwrap since can_bypass_validation checks user existence
         };
 
-        return ValidationResult::bypassed(bypass_info);
+        return TitleValidationResult {
+            validation: ValidationResult::bypassed(bypass_info),
+            diagnosis: None,
+        };
     }
 
     // Otherwise, perform normal validation
     let regex = match Regex::new(&current_configuration.title_pattern) {
         Ok(r) => r,
-        Err(_) => return ValidationResult::invalid(),
+        Err(_) => {
+            return TitleValidationResult {
+                validation: ValidationResult::invalid(),
+                diagnosis: Some(diagnose_pr_title(&pr.title)),
+            }
+        }
     };
 
     if regex.is_match(&pr.title) {
-        ValidationResult::valid()
+        TitleValidationResult {
+            validation: ValidationResult::valid(),
+            diagnosis: None,
+        }
     } else {
-        ValidationResult::invalid()
+        let diagnosis = diagnose_pr_title(&pr.title);
+        TitleValidationResult {
+            validation: ValidationResult::invalid(),
+            diagnosis: Some(diagnosis),
+        }
     }
 }
 

--- a/crates/core/src/checks.rs
+++ b/crates/core/src/checks.rs
@@ -17,6 +17,7 @@ use crate::{
 use merge_warden_developer_platforms::models::{PullRequest, PullRequestFile, User};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::sync::OnceLock;
 
 /// Compiled once at first use. Handles all four supported closing-keyword formats:
@@ -371,6 +372,60 @@ pub enum TitleIssue {
     },
 }
 
+impl fmt::Display for TitleIssue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LeadingWhitespace => write!(
+                f,
+                "The title starts with whitespace \u{2014} please remove the leading spaces."
+            ),
+            Self::WhitespaceBeforeColon { found } => write!(
+                f,
+                "There is whitespace before the `:` separator (found `{found}`) \u{2014} remove the extra space."
+            ),
+            Self::UppercaseType { found } => write!(
+                f,
+                "The type `{found}` must be lowercase (e.g. use `{}` instead).",
+                found.to_lowercase()
+            ),
+            Self::UnrecognizedType {
+                found,
+                nearest_valid: Some(nv),
+            } => write!(
+                f,
+                "The type `{found}` is not a recognized conventional commit type \u{2014} did you mean `{nv}`?"
+            ),
+            Self::UnrecognizedType {
+                found,
+                nearest_valid: None,
+            } => write!(
+                f,
+                "The type `{found}` is not a recognized conventional commit type."
+            ),
+            Self::MissingColon => write!(
+                f,
+                "A `:` separator is required between the type/scope and the description (e.g. `feat: ...`)."
+            ),
+            Self::MissingSpaceAfterColon => write!(
+                f,
+                "A space is required after the `:` separator (e.g. `feat: description`)."
+            ),
+            Self::EmptyDescription => write!(
+                f,
+                "The description after `:` is missing or blank \u{2014} please add a short summary."
+            ),
+            Self::InvalidScope { scope } => write!(
+                f,
+                "The scope `{scope}` contains invalid characters; scopes must only use lowercase letters, digits, `_`, and `-`."
+            ),
+            Self::NoTypePrefix => write!(
+                f,
+                "No conventional commit type prefix was found at the start of the title."
+            ),
+        }
+    }
+}
+
 /// Common typo / synonym mappings from a known-wrong type word to the correct one.
 ///
 /// Used by [`diagnose_pr_title`] to populate [`TitleIssue::UnrecognizedType::nearest_valid`]
@@ -416,7 +471,6 @@ fn build_suggested_fix(working: &str, issues: &[TitleIssue]) -> Option<String> {
 
     // Fix UppercaseType or UnrecognizedType — replace the type token at the start.
     let token_end = result.find(['(', '!', ':', ' ']).unwrap_or(result.len());
-    let raw_token = result[..token_end].to_string();
     let replacement_token: Option<String> = issues.iter().find_map(|i| match i {
         TitleIssue::UppercaseType { found } => Some(found.to_lowercase()),
         TitleIssue::UnrecognizedType { nearest_valid, .. } => nearest_valid.clone(),
@@ -471,8 +525,6 @@ fn build_suggested_fix(working: &str, issues: &[TitleIssue]) -> Option<String> {
         }
     }
 
-    // Guard against producing the same string as the original.
-    let _ = raw_token; // used implicitly above
     Some(result)
 }
 
@@ -483,11 +535,7 @@ fn build_suggested_fix(working: &str, issues: &[TitleIssue]) -> Option<String> {
 /// caller to receive a complete picture of all problems at once.
 ///
 /// Appends the relevant [`TitleIssue`] variant(s) found in the working title.
-fn check_colon_issues(
-    working: &str,
-    colon_pos: Option<usize>,
-    issues: &mut Vec<TitleIssue>,
-) {
+fn check_colon_issues(working: &str, colon_pos: Option<usize>, issues: &mut Vec<TitleIssue>) {
     if colon_pos.is_none() {
         // ── Step 5: Missing colon ─────────────────────────────────────────────
         issues.push(TitleIssue::MissingColon);
@@ -760,7 +808,11 @@ pub fn check_pr_title(
         };
     }
 
-    // Otherwise, perform normal validation
+    // Otherwise, perform normal validation.
+    // NOTE: The title_pattern regex is recompiled on every call. Since the pattern is
+    // configuration-derived (not static), OnceLock is not suitable here. A per-instance
+    // cache keyed by pattern string would improve throughput under high load.
+    // This is a known performance gap — tracked for future optimisation.
     let regex = match Regex::new(&current_configuration.title_pattern) {
         Ok(r) => r,
         Err(_) => {

--- a/crates/core/src/checks.rs
+++ b/crates/core/src/checks.rs
@@ -385,6 +385,142 @@ const TYPE_TYPO_MAP: &[(&str, &str)] = &[
     ("hotfix", "fix"),
 ];
 
+/// Constructs a best-effort corrected title from the working (trimmed) title and the
+/// list of issues that were diagnosed.
+///
+/// Returns `None` when the problems are unresolvable (e.g. `NoTypePrefix`,
+/// `EmptyDescription`).
+fn build_suggested_fix(working: &str, issues: &[TitleIssue]) -> Option<String> {
+    // Unresolvable issues: no fix possible.
+    // UnrecognizedType without a nearest_valid is also unresolvable — we don't know
+    // what type the author intended, so we cannot suggest a corrected title.
+    let unresolvable = issues.iter().any(|i| {
+        matches!(
+            i,
+            TitleIssue::NoTypePrefix
+                | TitleIssue::EmptyDescription
+                | TitleIssue::UnrecognizedType {
+                    nearest_valid: None,
+                    ..
+                }
+        )
+    });
+    if unresolvable {
+        return None;
+    }
+
+    let mut result = working.to_string();
+
+    // Apply corrections in reverse order of their lexical position so that
+    // index-based mutations don't invalidate later positions.
+
+    // Fix UppercaseType or UnrecognizedType — replace the type token at the start.
+    let token_end = result.find(['(', '!', ':', ' ']).unwrap_or(result.len());
+    let raw_token = result[..token_end].to_string();
+    let replacement_token: Option<String> = issues.iter().find_map(|i| match i {
+        TitleIssue::UppercaseType { found } => Some(found.to_lowercase()),
+        TitleIssue::UnrecognizedType { nearest_valid, .. } => nearest_valid.clone(),
+        _ => None,
+    });
+    if let Some(ref rep) = replacement_token {
+        result = format!("{}{}", rep, &result[token_end..]);
+    }
+
+    // Fix WhitespaceBeforeColon — remove whitespace directly before the colon.
+    if issues
+        .iter()
+        .any(|i| matches!(i, TitleIssue::WhitespaceBeforeColon { .. }))
+    {
+        // After possibly replacing the type token, find and strip whitespace before `:`.
+        if let Some(colon_pos) = result.find(':') {
+            let trimmed_prefix = result[..colon_pos].trim_end().to_string();
+            let after_colon = result[colon_pos..].to_string();
+            result = format!("{trimmed_prefix}{after_colon}");
+        }
+    }
+
+    // Fix InvalidScope — lowercase the scope and replace spaces with `-`.
+    if let Some(TitleIssue::InvalidScope { scope }) = issues
+        .iter()
+        .find(|i| matches!(i, TitleIssue::InvalidScope { .. }))
+    {
+        let fixed_scope = scope.to_lowercase().replace(' ', "-");
+        // Replace only the first occurrence of `(<scope>)` in the result.
+        let needle = format!("({scope})");
+        let replacement = format!("({fixed_scope})");
+        result = result.replacen(&needle, &replacement, 1);
+    }
+
+    // Fix MissingColon — insert `:` after the type token (and optional scope/!).
+    if issues.iter().any(|i| matches!(i, TitleIssue::MissingColon)) {
+        // Find the end of the type+scope+! prefix.
+        let prefix_end = result.find(' ').unwrap_or(result.len());
+        result = format!("{}:{}", &result[..prefix_end], &result[prefix_end..]);
+    }
+
+    // Fix MissingSpaceAfterColon — insert a space after the colon.
+    if issues
+        .iter()
+        .any(|i| matches!(i, TitleIssue::MissingSpaceAfterColon))
+    {
+        if let Some(colon_pos) = result.find(':') {
+            let after = &result[colon_pos + 1..];
+            if !after.starts_with(' ') {
+                result = format!("{}: {}", &result[..colon_pos], after);
+            }
+        }
+    }
+
+    // Guard against producing the same string as the original.
+    let _ = raw_token; // used implicitly above
+    Some(result)
+}
+
+/// Checks for missing-colon, missing-space-after-colon, and empty-description issues.
+///
+/// Appends the relevant [`TitleIssue`] variant(s) found in the working title.
+fn check_colon_issues(
+    working: &str,
+    colon_pos: Option<usize>,
+    type_token_diagnosed: bool,
+    issues: &mut Vec<TitleIssue>,
+) {
+    if colon_pos.is_none() && !type_token_diagnosed {
+        // ── Step 5: Missing colon ─────────────────────────────────────────────
+        issues.push(TitleIssue::MissingColon);
+    } else if let Some(colon) = colon_pos {
+        let after_colon = &working[colon + 1..];
+        if !after_colon.is_empty() && !after_colon.starts_with(' ') {
+            // ── Step 6: Missing space after colon ─────────────────────────────
+            issues.push(TitleIssue::MissingSpaceAfterColon);
+        } else if after_colon.trim().is_empty() {
+            // ── Step 7: Empty description ──────────────────────────────────────
+            issues.push(TitleIssue::EmptyDescription);
+        }
+    }
+}
+
+/// Checks for an invalid scope in the working title and appends [`TitleIssue::InvalidScope`]
+/// when found.
+///
+/// A scope is considered invalid when it contains characters outside `[a-z0-9_-]`.
+fn check_scope(working: &str, issues: &mut Vec<TitleIssue>) {
+    if let Some(scope_start) = working.find('(') {
+        let scope_end = working[scope_start..].find(')').map(|i| scope_start + i);
+        if let Some(end) = scope_end {
+            let scope_content = &working[scope_start + 1..end];
+            let scope_invalid = scope_content
+                .chars()
+                .any(|c| !matches!(c, 'a'..='z' | '0'..='9' | '_' | '-'));
+            if scope_invalid {
+                issues.push(TitleIssue::InvalidScope {
+                    scope: scope_content.to_string(),
+                });
+            }
+        }
+    }
+}
+
 /// Analyses a PR title that is known to be invalid and returns a structured diagnosis
 /// describing every detected problem and, where possible, a suggested corrected title.
 ///
@@ -542,143 +678,6 @@ pub fn diagnose_pr_title(title: &str) -> TitleDiagnosis {
         issues,
         suggested_fix,
     }
-}
-
-/// Checks for an invalid scope in the working title and appends [`TitleIssue::InvalidScope`]
-/// when found.
-///
-/// A scope is considered invalid when it contains characters outside `[a-z0-9_-]`.
-fn check_scope(working: &str, issues: &mut Vec<TitleIssue>) {
-    if let Some(scope_start) = working.find('(') {
-        let scope_end = working[scope_start..].find(')').map(|i| scope_start + i);
-        if let Some(end) = scope_end {
-            let scope_content = &working[scope_start + 1..end];
-            let scope_invalid = scope_content
-                .chars()
-                .any(|c| !matches!(c, 'a'..='z' | '0'..='9' | '_' | '-'));
-            if scope_invalid {
-                issues.push(TitleIssue::InvalidScope {
-                    scope: scope_content.to_string(),
-                });
-            }
-        }
-    }
-}
-
-/// Checks for missing-colon, missing-space-after-colon, and empty-description issues.
-///
-/// Appends the relevant [`TitleIssue`] variant(s) found in the working title.
-fn check_colon_issues(
-    working: &str,
-    colon_pos: Option<usize>,
-    type_token_diagnosed: bool,
-    issues: &mut Vec<TitleIssue>,
-) {
-    if colon_pos.is_none() && !type_token_diagnosed {
-        // ── Step 5: Missing colon ─────────────────────────────────────────────
-        issues.push(TitleIssue::MissingColon);
-    } else if let Some(colon) = colon_pos {
-        let after_colon = &working[colon + 1..];
-        if !after_colon.is_empty() && !after_colon.starts_with(' ') {
-            // ── Step 6: Missing space after colon ─────────────────────────────
-            issues.push(TitleIssue::MissingSpaceAfterColon);
-        } else if after_colon.trim().is_empty() {
-            // ── Step 7: Empty description ──────────────────────────────────────
-            issues.push(TitleIssue::EmptyDescription);
-        }
-    }
-}
-
-/// Constructs a best-effort corrected title from the working (trimmed) title and the
-/// list of issues that were diagnosed.
-///
-/// Returns `None` when the problems are unresolvable (e.g. `NoTypePrefix`,
-/// `EmptyDescription`).
-fn build_suggested_fix(working: &str, issues: &[TitleIssue]) -> Option<String> {
-    // Unresolvable issues: no fix possible.
-    // UnrecognizedType without a nearest_valid is also unresolvable — we don't know
-    // what type the author intended, so we cannot suggest a corrected title.
-    let unresolvable = issues.iter().any(|i| {
-        matches!(
-            i,
-            TitleIssue::NoTypePrefix
-                | TitleIssue::EmptyDescription
-                | TitleIssue::UnrecognizedType {
-                    nearest_valid: None,
-                    ..
-                }
-        )
-    });
-    if unresolvable {
-        return None;
-    }
-
-    let mut result = working.to_string();
-
-    // Apply corrections in reverse order of their lexical position so that
-    // index-based mutations don't invalidate later positions.
-
-    // Fix UppercaseType or UnrecognizedType — replace the type token at the start.
-    let token_end = result.find(['(', '!', ':', ' ']).unwrap_or(result.len());
-    let raw_token = result[..token_end].to_string();
-    let replacement_token: Option<String> = issues.iter().find_map(|i| match i {
-        TitleIssue::UppercaseType { found } => Some(found.to_lowercase()),
-        TitleIssue::UnrecognizedType { nearest_valid, .. } => nearest_valid.clone(),
-        _ => None,
-    });
-    if let Some(ref rep) = replacement_token {
-        result = format!("{}{}", rep, &result[token_end..]);
-    }
-
-    // Fix WhitespaceBeforeColon — remove whitespace directly before the colon.
-    if issues
-        .iter()
-        .any(|i| matches!(i, TitleIssue::WhitespaceBeforeColon { .. }))
-    {
-        // After possibly replacing the type token, find and strip whitespace before `:`.
-        if let Some(colon_pos) = result.find(':') {
-            let trimmed_prefix = result[..colon_pos].trim_end().to_string();
-            let after_colon = result[colon_pos..].to_string();
-            result = format!("{trimmed_prefix}{after_colon}");
-        }
-    }
-
-    // Fix InvalidScope — lowercase the scope and replace spaces with `-`.
-    if let Some(TitleIssue::InvalidScope { scope }) = issues
-        .iter()
-        .find(|i| matches!(i, TitleIssue::InvalidScope { .. }))
-    {
-        let fixed_scope = scope.to_lowercase().replace(' ', "-");
-        // Replace only the first occurrence of `(<scope>)` in the result.
-        let needle = format!("({scope})");
-        let replacement = format!("({fixed_scope})");
-        result = result.replacen(&needle, &replacement, 1);
-    }
-
-    // Fix MissingColon — insert `:` after the type token (and optional scope/!).
-    if issues.iter().any(|i| matches!(i, TitleIssue::MissingColon)) {
-        // Find the end of the type+scope+! prefix.
-        let prefix_end = result.find(' ').unwrap_or(result.len());
-        result = format!("{}:{}", &result[..prefix_end], &result[prefix_end..]);
-    }
-
-    // Fix MissingSpaceAfterColon — insert a space after the colon.
-    if issues
-        .iter()
-        .any(|i| matches!(i, TitleIssue::MissingSpaceAfterColon))
-    {
-        if let Some(colon_pos) = result.find(':') {
-            let after = &result[colon_pos + 1..];
-            if !after.starts_with(' ') {
-                result = format!("{}: {}", &result[..colon_pos], after);
-            }
-        }
-    }
-
-    // Replace the token string "Some(raw)"/None label note if replacements were
-    // performed; also guard against producing the same string as the original.
-    let _ = raw_token; // used implicitly above
-    Some(result)
 }
 
 /// Validates that the PR title follows the Conventional Commits format with bypass support.

--- a/crates/core/src/checks.rs
+++ b/crates/core/src/checks.rs
@@ -478,14 +478,17 @@ fn build_suggested_fix(working: &str, issues: &[TitleIssue]) -> Option<String> {
 
 /// Checks for missing-colon, missing-space-after-colon, and empty-description issues.
 ///
+/// `MissingColon` is reported whenever there is no `:` in the title, regardless of any other
+/// type issues already recorded (e.g. `UppercaseType` or `UnrecognizedType`). This allows the
+/// caller to receive a complete picture of all problems at once.
+///
 /// Appends the relevant [`TitleIssue`] variant(s) found in the working title.
 fn check_colon_issues(
     working: &str,
     colon_pos: Option<usize>,
-    type_token_diagnosed: bool,
     issues: &mut Vec<TitleIssue>,
 ) {
-    if colon_pos.is_none() && !type_token_diagnosed {
+    if colon_pos.is_none() {
         // ── Step 5: Missing colon ─────────────────────────────────────────────
         issues.push(TitleIssue::MissingColon);
     } else if let Some(colon) = colon_pos {
@@ -600,17 +603,12 @@ pub fn diagnose_pr_title(title: &str) -> TitleDiagnosis {
     let is_valid_exact = VALID_PR_TYPES.contains(&raw_token);
     let is_valid_lower = VALID_PR_TYPES.contains(&token_lower.as_str());
 
-    // Track what we have already diagnosed about the type token so we can skip
-    // the MissingColon / MissingSpaceAfterColon checks when appropriate.
-    let mut type_token_diagnosed = false;
-
     if !raw_token.is_empty() && !is_valid_exact {
         if is_valid_lower {
             // ── Step 4: Uppercase type ────────────────────────────────────────
             issues.push(TitleIssue::UppercaseType {
                 found: raw_token.to_string(),
             });
-            type_token_diagnosed = true;
         } else {
             // ── Step 3: Unrecognised type ─────────────────────────────────────
             // Only diagnose as UnrecognizedType when there is a colon (indicating a
@@ -625,7 +623,6 @@ pub fn diagnose_pr_title(title: &str) -> TitleDiagnosis {
                     found: raw_token.to_string(),
                     nearest_valid,
                 });
-                type_token_diagnosed = true;
             }
         }
     }
@@ -644,7 +641,7 @@ pub fn diagnose_pr_title(title: &str) -> TitleDiagnosis {
 
     if let Some(ref _eff_token) = effective_token {
         check_scope(working, &mut issues);
-        check_colon_issues(working, colon_pos, type_token_diagnosed, &mut issues);
+        check_colon_issues(working, colon_pos, &mut issues);
     }
 
     // ── Step 9: NoTypePrefix fallback ────────────────────────────────────────

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -668,20 +668,18 @@ Your PR title does not follow the [Conventional Commits](https://www.conventiona
 Please update the PR title to match the conventional commit message guidelines.";
 
             let comment_text = {
-                // 4.2: extract diagnosis (guaranteed Some when !is_valid and not bypassed)
+                // Build the diagnosis section: one bullet per TitleIssue, optional suggested fix.
                 let mut diagnosis_section =
                     String::from("\nThe pull request title needs correction:\n");
                 if let Some(diagnosis) = validation_result.diagnosis.as_ref() {
-                    // 4.3: build diagnosis section — one bullet per TitleIssue
                     for issue in &diagnosis.issues {
                         diagnosis_section.push_str(&format!("- {}\n", format_title_issue(issue)));
                     }
                     if let Some(fix) = &diagnosis.suggested_fix {
-                        // 4.3: append suggested fix when available
                         diagnosis_section.push_str(&format!("\nSuggested fix: `{fix}`"));
                     }
                 }
-                // 4.4: compose final comment_text = diagnosis_section + separator + format reminder
+                // Compose final comment: diagnosis section + separator + general format reminder.
                 format!("{diagnosis_section}\n\n{format_reminder}")
             };
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -647,13 +647,12 @@ impl<P: PullRequestProvider + std::fmt::Debug> MergeWarden<P> {
                 .await)
                 .unwrap_or_default();
 
-            let mut has_comment = false;
-            for comment in comments {
-                if comment.body.contains(TITLE_COMMENT_MARKER) {
-                    has_comment = true;
-                    break;
-                }
-            }
+            // Find any existing comment with TITLE_COMMENT_MARKER (capture id + body so we
+            // can replace it when the diagnosis changes between two invalid push events).
+            let existing_comment = comments
+                .iter()
+                .find(|c| c.body.contains(TITLE_COMMENT_MARKER))
+                .map(|c| (c.id, c.body.clone()));
 
             // Add comment with diagnosis and format reminder
             let format_reminder = "\
@@ -673,7 +672,7 @@ Please update the PR title to match the conventional commit message guidelines."
                     String::from("\nThe pull request title needs correction:\n");
                 if let Some(diagnosis) = validation_result.diagnosis.as_ref() {
                     for issue in &diagnosis.issues {
-                        diagnosis_section.push_str(&format!("- {}\n", format_title_issue(issue)));
+                        diagnosis_section.push_str(&format!("- {issue}\n"));
                     }
                     if let Some(fix) = &diagnosis.suggested_fix {
                         diagnosis_section.push_str(&format!("\nSuggested fix: `{fix}`"));
@@ -688,7 +687,33 @@ Please update the PR title to match the conventional commit message guidelines."
                 prefix = TITLE_COMMENT_MARKER,
                 text = comment_text
             );
-            if !has_comment {
+
+            // Post or replace the comment:
+            // - No prior comment → add new one.
+            // - Prior comment with different body → delete stale comment then add the updated
+            //   one so the author receives a fresh notification when the diagnosis changes.
+            // - Prior comment with identical body → skip (idempotent, avoids notification spam).
+            let should_post = match &existing_comment {
+                None => true,
+                Some((_, existing_body)) => existing_body != &comment,
+            };
+
+            if should_post {
+                if let Some((existing_id, _)) = existing_comment {
+                    let del_result = self
+                        .provider
+                        .delete_comment(repo_owner, repo_name, existing_id)
+                        .await;
+                    if del_result.is_err() {
+                        warn!(
+                            repository_owner = repo_owner,
+                            repository = repo_name,
+                            pull_request = pr.number,
+                            "Failed to delete stale title validation comment before posting updated one."
+                        );
+                    }
+                }
+
                 let result = self
                     .provider
                     .add_comment(repo_owner, repo_name, pr.number, &comment)
@@ -2293,50 +2318,5 @@ Please update the PR body to include a valid work item reference."#;
     pub fn with_issue_provider(mut self, provider: Box<dyn IssueMetadataProvider>) -> Self {
         self.issue_provider = Some(provider);
         self
-    }
-}
-
-/// Returns a human-readable description of a single [`checks::TitleIssue`] for use in PR
-/// comments.
-///
-/// Each variant is mapped to a short, actionable sentence that explains the problem and, where
-/// applicable, shows how to correct it.
-fn format_title_issue(issue: &checks::TitleIssue) -> String {
-    match issue {
-        checks::TitleIssue::LeadingWhitespace => {
-            "The title starts with whitespace — please remove the leading spaces.".to_string()
-        }
-        checks::TitleIssue::WhitespaceBeforeColon { found } => format!(
-            "There is whitespace before the `:` separator (found `{found}`) — remove the extra space."
-        ),
-        checks::TitleIssue::UppercaseType { found } => format!(
-            "The type `{found}` must be lowercase (e.g. use `{}` instead).",
-            found.to_lowercase()
-        ),
-        checks::TitleIssue::UnrecognizedType {
-            found,
-            nearest_valid: Some(nv),
-        } => format!(
-            "The type `{found}` is not a recognised conventional commit type — did you mean `{nv}`?"
-        ),
-        checks::TitleIssue::UnrecognizedType {
-            found,
-            nearest_valid: None,
-        } => format!("The type `{found}` is not a recognised conventional commit type."),
-        checks::TitleIssue::MissingColon => {
-            "A `:` separator is required between the type/scope and the description (e.g. `feat: ...`).".to_string()
-        }
-        checks::TitleIssue::MissingSpaceAfterColon => {
-            "A space is required after the `:` separator (e.g. `feat: description`).".to_string()
-        }
-        checks::TitleIssue::EmptyDescription => {
-            "The description after `:` is missing or blank — please add a short summary.".to_string()
-        }
-        checks::TitleIssue::InvalidScope { scope } => format!(
-            "The scope `{scope}` contains invalid characters; scopes must only use lowercase letters, digits, `_`, and `-`."
-        ),
-        checks::TitleIssue::NoTypePrefix => {
-            "No conventional commit type prefix was found at the start of the title.".to_string()
-        }
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -213,9 +213,10 @@ impl<P: PullRequestProvider + std::fmt::Debug> MergeWarden<P> {
     ///
     /// # Returns
     ///
-    /// A `ValidationResult` containing validation status and bypass information
+    /// A `TitleValidationResult` containing validation status, bypass information,
+    /// and structured diagnosis when the title is invalid
     #[instrument]
-    fn check_title(&self, pr: &PullRequest) -> validation_result::ValidationResult {
+    fn check_title(&self, pr: &PullRequest) -> checks::TitleValidationResult {
         debug!(pull_request = pr.number, "Checking PR title");
         checks::check_pr_title(
             pr,
@@ -545,7 +546,7 @@ impl<P: PullRequestProvider + std::fmt::Debug> MergeWarden<P> {
     /// * `repo_owner` - The owner of the repository
     /// * `repo_name` - The name of the repository
     /// * `pr` - The pull request to validate
-    /// * `validation_result` - The result of title validation including bypass information
+    /// * `validation_result` - The result of title validation including bypass information and diagnosis
     ///
     /// # Returns
     ///
@@ -556,7 +557,7 @@ impl<P: PullRequestProvider + std::fmt::Debug> MergeWarden<P> {
         repo_owner: &str,
         repo_name: &str,
         pr: &PullRequest,
-        validation_result: &validation_result::ValidationResult,
+        validation_result: &checks::TitleValidationResult,
     ) -> String {
         info!(
             repository_owner = repo_owner,
@@ -654,19 +655,35 @@ impl<P: PullRequestProvider + std::fmt::Debug> MergeWarden<P> {
                 }
             }
 
-            // Add comment with suggestions
-            let comment_text = r#"
-The pull request title needs correction:
+            // Add comment with diagnosis and format reminder
+            let format_reminder = "\
+Your PR title does not follow the [Conventional Commits](https://www.conventionalcommits.org/) message format.\n\
+- Supported types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert\n\
+- Expected format: `<type>(<optional scope>): <description>`\n\
+- Examples:\n\
+    * feat(auth): add login functionality\n\
+    * fix: resolve null pointer exception\n\
+- For full details, see: https://www.conventionalcommits.org/\n\
+\n\
+Please update the PR title to match the conventional commit message guidelines.";
 
-Your PR title does not follow the [Conventional Commits](https://www.conventionalcommits.org/) message format.
-- Supported types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
-- Expected format: `<type>(<optional scope>): <description>`
-- Examples:
-    * feat(auth): add login functionality
-    * fix: resolve null pointer exception
-- For full details, see: https://www.conventionalcommits.org/
-
-Please update the PR title to match the conventional commit message guidelines."#;
+            let comment_text = {
+                // 4.2: extract diagnosis (guaranteed Some when !is_valid and not bypassed)
+                let mut diagnosis_section =
+                    String::from("\nThe pull request title needs correction:\n");
+                if let Some(diagnosis) = validation_result.diagnosis.as_ref() {
+                    // 4.3: build diagnosis section — one bullet per TitleIssue
+                    for issue in &diagnosis.issues {
+                        diagnosis_section.push_str(&format!("- {}\n", format_title_issue(issue)));
+                    }
+                    if let Some(fix) = &diagnosis.suggested_fix {
+                        // 4.3: append suggested fix when available
+                        diagnosis_section.push_str(&format!("\nSuggested fix: `{fix}`"));
+                    }
+                }
+                // 4.4: compose final comment_text = diagnosis_section + separator + format reminder
+                format!("{diagnosis_section}\n\n{format_reminder}")
+            };
 
             let comment = format!(
                 "{prefix}{text}",
@@ -698,7 +715,7 @@ Please update the PR title to match the conventional commit message guidelines."
                 }
             }
 
-            comment_text.to_string()
+            comment_text
         } else {
             // Title validation passed (either valid or bypassed)
 
@@ -1930,7 +1947,10 @@ Please update the PR body to include a valid work item reference."#;
         let title_result = if self.config.enforce_title_convention {
             self.check_title(&pr)
         } else {
-            validation_result::ValidationResult::valid()
+            checks::TitleValidationResult {
+                validation: validation_result::ValidationResult::valid(),
+                diagnosis: None,
+            }
         };
 
         // Check that the PR body has a reference to a work item if enabled
@@ -2275,5 +2295,50 @@ Please update the PR body to include a valid work item reference."#;
     pub fn with_issue_provider(mut self, provider: Box<dyn IssueMetadataProvider>) -> Self {
         self.issue_provider = Some(provider);
         self
+    }
+}
+
+/// Returns a human-readable description of a single [`checks::TitleIssue`] for use in PR
+/// comments.
+///
+/// Each variant is mapped to a short, actionable sentence that explains the problem and, where
+/// applicable, shows how to correct it.
+fn format_title_issue(issue: &checks::TitleIssue) -> String {
+    match issue {
+        checks::TitleIssue::LeadingWhitespace => {
+            "The title starts with whitespace — please remove the leading spaces.".to_string()
+        }
+        checks::TitleIssue::WhitespaceBeforeColon { found } => format!(
+            "There is whitespace before the `:` separator (found `{found}`) — remove the extra space."
+        ),
+        checks::TitleIssue::UppercaseType { found } => format!(
+            "The type `{found}` must be lowercase (e.g. use `{}` instead).",
+            found.to_lowercase()
+        ),
+        checks::TitleIssue::UnrecognizedType {
+            found,
+            nearest_valid: Some(nv),
+        } => format!(
+            "The type `{found}` is not a recognised conventional commit type — did you mean `{nv}`?"
+        ),
+        checks::TitleIssue::UnrecognizedType {
+            found,
+            nearest_valid: None,
+        } => format!("The type `{found}` is not a recognised conventional commit type."),
+        checks::TitleIssue::MissingColon => {
+            "A `:` separator is required between the type/scope and the description (e.g. `feat: ...`).".to_string()
+        }
+        checks::TitleIssue::MissingSpaceAfterColon => {
+            "A space is required after the `:` separator (e.g. `feat: description`).".to_string()
+        }
+        checks::TitleIssue::EmptyDescription => {
+            "The description after `:` is missing or blank — please add a short summary.".to_string()
+        }
+        checks::TitleIssue::InvalidScope { scope } => format!(
+            "The scope `{scope}` contains invalid characters; scopes must only use lowercase letters, digits, `_`, and `-`."
+        ),
+        checks::TitleIssue::NoTypePrefix => {
+            "No conventional commit type prefix was found at the start of the title.".to_string()
+        }
     }
 }

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -3127,3 +3127,259 @@ async fn test_process_pull_request_skips_propagation_without_issue_provider() {
     // If we reach here without a panic, the test passes. There is no issue
     // provider to assert on since none was supplied.
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Task 5.0 — Tests for targeted comment content produced by
+// communicate_pr_title_validity_status() for each TitleIssue variant.
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Build a minimal `PullRequest` with the given number and title.
+///
+/// The body always contains a valid work item reference so that work-item
+/// validation does not interfere with the assertions about title comments.
+fn make_pr_for_title_test(number: u64, title: &str) -> PullRequest {
+    PullRequest {
+        number,
+        title: title.to_string(),
+        draft: false,
+        body: Some("Fixes #123".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    }
+}
+
+/// Build a `DynamicMockGitProvider` that already contains `pr`.
+fn provider_with_pr(pr: PullRequest) -> DynamicMockGitProvider {
+    let mut provider = DynamicMockGitProvider::new();
+    provider.add_pull_request(pr);
+    provider
+}
+
+/// Return the single title-related comment body from the provider, or panic
+/// if none (or more than one) was found.
+fn get_title_comment(comments: Vec<Comment>) -> String {
+    let title_comments: Vec<_> = comments
+        .iter()
+        .filter(|c| c.body.contains(TITLE_COMMENT_MARKER))
+        .collect();
+    assert_eq!(
+        title_comments.len(),
+        1,
+        "expected exactly one title comment, got {}: {:?}",
+        title_comments.len(),
+        title_comments.iter().map(|c| &c.body).collect::<Vec<_>>()
+    );
+    title_comments[0].body.clone()
+}
+
+#[tokio::test]
+async fn test_comment_contains_leading_whitespace_message_and_suggested_fix() {
+    // 5.1 — Title " feat: add login" triggers LeadingWhitespace.
+    let pr = make_pr_for_title_test(1, " feat: add login");
+    let provider = provider_with_pr(pr);
+    let warden = MergeWarden::new(provider);
+
+    let result = warden
+        .process_pull_request("owner", "repo", 1)
+        .await
+        .unwrap();
+    assert!(!result.title_valid, "title should be invalid");
+
+    let body = get_title_comment(warden.provider.get_comments());
+    assert!(
+        body.contains("starts with whitespace"),
+        "comment should describe leading-whitespace issue; got:\n{body}"
+    );
+    assert!(
+        body.contains("Suggested fix: `feat: add login`"),
+        "comment should include suggested fix; got:\n{body}"
+    );
+    assert!(
+        body.contains("Conventional Commits"),
+        "comment should include general format reminder; got:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn test_comment_contains_whitespace_before_colon_message_and_suggested_fix() {
+    // 5.2 — Title "feat : add login" triggers WhitespaceBeforeColon.
+    let pr = make_pr_for_title_test(2, "feat : add login");
+    let provider = provider_with_pr(pr);
+    let warden = MergeWarden::new(provider);
+
+    let result = warden
+        .process_pull_request("owner", "repo", 2)
+        .await
+        .unwrap();
+    assert!(!result.title_valid, "title should be invalid");
+
+    let body = get_title_comment(warden.provider.get_comments());
+    assert!(
+        body.contains("whitespace before the `:` separator"),
+        "comment should describe whitespace-before-colon issue; got:\n{body}"
+    );
+    assert!(
+        body.contains("Suggested fix: `feat: add login`"),
+        "comment should include suggested fix; got:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn test_comment_contains_uppercase_type_message_and_suggested_fix_and_reminder() {
+    // 5.3 — Title "FEAT: add login" triggers UppercaseType.
+    let pr = make_pr_for_title_test(3, "FEAT: add login");
+    let provider = provider_with_pr(pr);
+    let warden = MergeWarden::new(provider);
+
+    let result = warden
+        .process_pull_request("owner", "repo", 3)
+        .await
+        .unwrap();
+    assert!(!result.title_valid, "title should be invalid");
+
+    let body = get_title_comment(warden.provider.get_comments());
+    assert!(
+        body.contains("must be lowercase"),
+        "comment should describe uppercase-type issue; got:\n{body}"
+    );
+    assert!(
+        body.contains("Suggested fix: `feat: add login`"),
+        "comment should include suggested fix; got:\n{body}"
+    );
+    assert!(
+        body.contains("Conventional Commits"),
+        "comment should include general format reminder; got:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn test_comment_contains_unrecognized_type_message_with_nearest_valid_suggestion() {
+    // 5.4 — Title "feature: add login" triggers UnrecognizedType with nearest_valid "feat".
+    let pr = make_pr_for_title_test(4, "feature: add login");
+    let provider = provider_with_pr(pr);
+    let warden = MergeWarden::new(provider);
+
+    let result = warden
+        .process_pull_request("owner", "repo", 4)
+        .await
+        .unwrap();
+    assert!(!result.title_valid, "title should be invalid");
+
+    let body = get_title_comment(warden.provider.get_comments());
+    assert!(
+        body.contains("not a recognised conventional commit type"),
+        "comment should describe unrecognised-type issue; got:\n{body}"
+    );
+    assert!(
+        body.contains("`feat`"),
+        "comment should mention the nearest valid type; got:\n{body}"
+    );
+    assert!(
+        body.contains("Suggested fix: `feat: add login`"),
+        "comment should include suggested fix; got:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn test_comment_contains_missing_colon_message_and_suggested_fix() {
+    // 5.5 — Title "feat add login" triggers MissingColon.
+    let pr = make_pr_for_title_test(5, "feat add login");
+    let provider = provider_with_pr(pr);
+    let warden = MergeWarden::new(provider);
+
+    let result = warden
+        .process_pull_request("owner", "repo", 5)
+        .await
+        .unwrap();
+    assert!(!result.title_valid, "title should be invalid");
+
+    let body = get_title_comment(warden.provider.get_comments());
+    assert!(
+        body.contains("`:` separator is required"),
+        "comment should describe missing-colon issue; got:\n{body}"
+    );
+    assert!(
+        body.contains("Suggested fix: `feat: add login`"),
+        "comment should include suggested fix; got:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn test_comment_contains_missing_space_after_colon_message_and_suggested_fix() {
+    // 5.6 — Title "feat:add login" triggers MissingSpaceAfterColon.
+    let pr = make_pr_for_title_test(6, "feat:add login");
+    let provider = provider_with_pr(pr);
+    let warden = MergeWarden::new(provider);
+
+    let result = warden
+        .process_pull_request("owner", "repo", 6)
+        .await
+        .unwrap();
+    assert!(!result.title_valid, "title should be invalid");
+
+    let body = get_title_comment(warden.provider.get_comments());
+    assert!(
+        body.contains("space is required after the `:` separator"),
+        "comment should describe missing-space-after-colon issue; got:\n{body}"
+    );
+    assert!(
+        body.contains("Suggested fix: `feat: add login`"),
+        "comment should include suggested fix; got:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn test_comment_contains_no_type_prefix_message_and_no_suggested_fix_line() {
+    // 5.7 — Title "Add login functionality" triggers NoTypePrefix; no suggested fix.
+    let pr = make_pr_for_title_test(7, "Add login functionality");
+    let provider = provider_with_pr(pr);
+    let warden = MergeWarden::new(provider);
+
+    let result = warden
+        .process_pull_request("owner", "repo", 7)
+        .await
+        .unwrap();
+    assert!(!result.title_valid, "title should be invalid");
+
+    let body = get_title_comment(warden.provider.get_comments());
+    assert!(
+        body.contains("No conventional commit type prefix"),
+        "comment should describe no-type-prefix issue; got:\n{body}"
+    );
+    assert!(
+        body.contains("Conventional Commits"),
+        "comment should include general format reminder; got:\n{body}"
+    );
+    assert!(
+        !body.contains("Suggested fix:"),
+        "comment must not include a suggested fix when none exists; got:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn test_no_title_comment_posted_when_enforce_title_convention_is_false() {
+    // 5.8 — When enforce_title_convention is false a comment must never be posted,
+    //        even for a title that would otherwise be invalid.
+    let pr = make_pr_for_title_test(8, "completely wrong title");
+    let provider = provider_with_pr(pr);
+
+    let config = CurrentPullRequestValidationConfiguration {
+        enforce_title_convention: false,
+        ..CurrentPullRequestValidationConfiguration::default()
+    };
+    let warden = MergeWarden::with_config(provider, config);
+
+    warden
+        .process_pull_request("owner", "repo", 8)
+        .await
+        .unwrap();
+
+    let comments = warden.provider.get_comments();
+    assert!(
+        !comments.iter().any(|c| c.body.contains(TITLE_COMMENT_MARKER)),
+        "no title comment should be posted when enforce_title_convention is false; got:\n{comments:?}"
+    );
+}

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -1,4 +1,5 @@
 use crate::{
+    checks::TitleValidationResult,
     config::{
         BypassRule, BypassRules, ChangeTypeLabelConfig, ConventionalCommitMappings,
         CurrentPullRequestValidationConfiguration, FallbackLabelSettings, IssuePropagationConfig,
@@ -914,7 +915,10 @@ async fn test_handle_title_validation_invalid_to_valid() {
     };
 
     // Handle title validation with valid title
-    let validation_result = ValidationResult::valid();
+    let validation_result = TitleValidationResult {
+        validation: ValidationResult::valid(),
+        diagnosis: None,
+    };
     warden
         .communicate_pr_title_validity_status("owner", "repo", &pr, &validation_result)
         .await;

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -3270,7 +3270,7 @@ async fn test_comment_contains_unrecognized_type_message_with_nearest_valid_sugg
 
     let body = get_title_comment(warden.provider.get_comments());
     assert!(
-        body.contains("not a recognised conventional commit type"),
+        body.contains("not a recognized conventional commit type"),
         "comment should describe unrecognised-type issue; got:\n{body}"
     );
     assert!(
@@ -3381,5 +3381,130 @@ async fn test_no_title_comment_posted_when_enforce_title_convention_is_false() {
     assert!(
         !comments.iter().any(|c| c.body.contains(TITLE_COMMENT_MARKER)),
         "no title comment should be posted when enforce_title_convention is false; got:\n{comments:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_stale_title_comment_is_replaced_when_diagnosis_changes() {
+    // When a PR title changes from one invalid form to another the pre-existing
+    // title-validation comment (with a different diagnosis body) must be replaced,
+    // not left stale, so the author sees up-to-date feedback.
+
+    let provider = MockGitProvider::new();
+
+    // Pre-seed a comment that represents a previous (now stale) diagnosis for an
+    // UppercaseType error ("FEAT").
+    let stale_comment = format!(
+        "{}\nThe pull request title needs correction:\n- The type `FEAT` must be lowercase",
+        TITLE_COMMENT_MARKER
+    );
+    provider
+        .add_comment("owner", "repo", 1, &stale_comment)
+        .await
+        .unwrap();
+
+    // The author has since pushed a new title that has a DIFFERENT issue:
+    // "feature" is an UnrecognizedType (synonym for "feat"), not an UppercaseType.
+    let pr = PullRequest {
+        number: 1,
+        title: "feature: add login".to_string(),
+        draft: false,
+        body: Some("Fixes #123".to_string()),
+        author: Some(User {
+            id: 456,
+            login: "developer123".to_string(),
+        }),
+        milestone_number: None,
+    };
+    provider.set_pull_request(pr);
+
+    let warden = MergeWarden::new(provider);
+    warden
+        .process_pull_request("owner", "repo", 1)
+        .await
+        .unwrap();
+
+    let comments = warden.provider.get_comments();
+    let title_comments: Vec<_> = comments
+        .iter()
+        .filter(|c| c.body.contains(TITLE_COMMENT_MARKER))
+        .collect();
+
+    assert_eq!(
+        title_comments.len(),
+        1,
+        "exactly one title comment should remain after diagnosis update; got: {:?}",
+        title_comments.iter().map(|c| &c.body).collect::<Vec<_>>()
+    );
+    assert!(
+        !title_comments[0].body.contains("must be lowercase"),
+        "stale UppercaseType message should no longer appear; got:\n{}",
+        title_comments[0].body
+    );
+    assert!(
+        title_comments[0]
+            .body
+            .contains("not a recognized conventional commit type"),
+        "updated comment should describe the UnrecognizedType issue; got:\n{}",
+        title_comments[0].body
+    );
+}
+
+#[tokio::test]
+async fn test_identical_title_comment_is_not_reposted() {
+    // When the title is unchanged between two push events the existing comment
+    // body is identical and should not be deleted-and-reposted (idempotent path).
+
+    let provider = MockGitProvider::new();
+
+    // Simulate a PR with an invalid title ("feature: ...") that has already
+    // been processed and has a comment on it.
+    let pr = PullRequest {
+        number: 1,
+        title: "feature: add login".to_string(),
+        draft: false,
+        body: Some("Fixes #123".to_string()),
+        author: Some(User {
+            id: 456,
+            login: "developer123".to_string(),
+        }),
+        milestone_number: None,
+    };
+    provider.set_pull_request(pr);
+
+    let warden = MergeWarden::new(provider);
+
+    // First processing run — comment is created.
+    warden
+        .process_pull_request("owner", "repo", 1)
+        .await
+        .unwrap();
+
+    let comment_count_after_first_run = warden
+        .provider
+        .get_comments()
+        .iter()
+        .filter(|c| c.body.contains(TITLE_COMMENT_MARKER))
+        .count();
+    assert_eq!(
+        comment_count_after_first_run, 1,
+        "first run should produce exactly one title comment"
+    );
+
+    // Second processing run with the same title — comment body is identical.
+    warden
+        .process_pull_request("owner", "repo", 1)
+        .await
+        .unwrap();
+
+    let comment_count_after_second_run = warden
+        .provider
+        .get_comments()
+        .iter()
+        .filter(|c| c.body.contains(TITLE_COMMENT_MARKER))
+        .count();
+    assert_eq!(
+        comment_count_after_second_run, 1,
+        "second run with identical title should not create a duplicate comment"
     );
 }

--- a/docs/spec/design/validation-engine.md
+++ b/docs/spec/design/validation-engine.md
@@ -1,7 +1,7 @@
 # Validation Engine
 
-**Version:** 1.0
-**Last Updated:** July 22, 2025
+**Version:** 1.1
+**Last Updated:** April 10, 2026
 
 ## Overview
 
@@ -192,15 +192,32 @@ impl ValidationRule for TitleValidationRule {
                 bypass_info: None,
             })
         } else {
+            // Run structural diagnosis to produce actionable, per-issue feedback.
+            // diagnose_pr_title() classifies each violation individually and attempts
+            // to synthesise a corrected title string when possible.
+            let diagnosis = diagnose_pr_title(title);
+
+            // Map each TitleIssue variant to a short human-readable sentence.
+            let suggestions: Vec<String> = diagnosis.issues.iter()
+                .map(format_title_issue)
+                .collect();
+
+            // Include the suggested fix in the message when one could be inferred.
+            let message = match &diagnosis.suggested_fix {
+                Some(fix) => format!(
+                    "Title does not follow conventional commit format.\n\
+                     Suggested fix: `{}`",
+                    fix
+                ),
+                None => "Title does not follow conventional commit format.".to_string(),
+            };
+
             Ok(RuleResult {
                 rule_name: self.name().to_string(),
                 status: RuleStatus::Failed,
                 severity: Severity::Error,
-                message: Some("Title does not follow conventional commit format".to_string()),
-                suggestions: vec![
-                    "Use format: type(scope): description".to_string(),
-                    "Valid types: feat, fix, docs, chore, refactor, test".to_string(),
-                ],
+                message: Some(message),
+                suggestions,
                 bypass_info: None,
             })
         }
@@ -242,6 +259,169 @@ impl TitleValidationRule {
     }
 }
 ```
+
+#### PR Title Diagnostic Types
+
+When title validation fails the engine runs `diagnose_pr_title()` to classify each
+violation individually and, where possible, synthesise a corrected title.  The result
+is carried in three concrete types that live in `merge_warden_core::checks`.
+
+##### `TitleIssue`
+
+A single structural violation found in the PR title.  Multiple variants can be present
+simultaneously (e.g. a title of `" FEAT: add login"` produces both `LeadingWhitespace`
+and `UppercaseType`).
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TitleIssue {
+    /// The description after `:` is absent or whitespace-only.
+    ///
+    /// No `suggested_fix` is produced because the user must supply meaningful content.
+    /// Examples: `"feat: "`, `"feat:  "`
+    EmptyDescription,
+
+    /// The scope contains characters outside `[a-z0-9_-]`.
+    ///
+    /// `suggested_fix` lowercases the scope and replaces spaces with `-`.
+    /// Examples: `"feat(Auth): …"`, `"feat(user service): …"`
+    InvalidScope { scope: String },
+
+    /// The title begins with one or more whitespace characters.
+    ///
+    /// This variant may appear alongside others; all subsequent checks operate on
+    /// the trimmed title.
+    /// Examples: `" feat: add login"`
+    LeadingWhitespace,
+
+    /// A recognised type token is present but not followed by `:`.
+    ///
+    /// `suggested_fix` inserts `:` after the type/scope prefix.
+    /// Examples: `"feat add login"`
+    MissingColon,
+
+    /// The `:` separator is present but the character immediately after it is not a space.
+    ///
+    /// `suggested_fix` inserts the missing space.
+    /// Examples: `"feat:add login"`
+    MissingSpaceAfterColon,
+
+    /// No recognisable type prefix was found at the start of the title.
+    ///
+    /// This is the general fallback when no other pattern matches.  No `suggested_fix`
+    /// is produced.
+    /// Examples: `"Add login functionality"`, `""`, `"   "`
+    NoTypePrefix,
+
+    /// The type token is not in the approved list and is not a known synonym.
+    ///
+    /// `nearest_valid` is `Some` when a known typo/synonym mapping exists (see
+    /// [`TYPE_TYPO_MAP`]); otherwise `None`.  `suggested_fix` is only produced when
+    /// `nearest_valid` is `Some`.
+    /// Examples: `"feature: …"` → `nearest_valid: Some("feat")`;
+    ///           `"xyz: …"` → `nearest_valid: None`
+    UnrecognizedType {
+        found: String,
+        nearest_valid: Option<String>,
+    },
+
+    /// The type token is a correctly-spelled approved type but is not all-lowercase.
+    ///
+    /// `suggested_fix` lowercases the type token.
+    /// Examples: `"FEAT: add login"`, `"Fix: bug"`
+    UppercaseType { found: String },
+
+    /// There is whitespace between the type/scope and the `:` separator.
+    ///
+    /// `suggested_fix` removes the extra whitespace.
+    /// Examples: `"feat : add login"`, `"feat(auth) : add login"`
+    WhitespaceBeforeColon { found: String },
+}
+```
+
+Known synonym / typo mappings that populate `UnrecognizedType::nearest_valid`:
+
+| User wrote | Corrected to |
+|------------|--------------|
+| `bug`      | `fix`        |
+| `bugfix`   | `fix`        |
+| `dep`      | `chore`      |
+| `dependencies` | `chore`  |
+| `enhancement` | `feat`    |
+| `feature`  | `feat`       |
+| `hotfix`   | `fix`        |
+
+##### `TitleDiagnosis`
+
+The structured outcome of running `diagnose_pr_title()` on a single title string.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TitleDiagnosis {
+    /// One entry per detected violation.  May contain multiple entries when several
+    /// problems are observed simultaneously.
+    pub issues: Vec<TitleIssue>,
+
+    /// A best-effort corrected title, or `None` when no fix can be inferred
+    /// (e.g. `NoTypePrefix`, `EmptyDescription`, or `UnrecognizedType` with no
+    /// nearest valid mapping).
+    pub suggested_fix: Option<String>,
+}
+```
+
+**Example** — title `"FEAT: add login"`:
+
+```rust
+TitleDiagnosis {
+    issues: vec![
+        TitleIssue::UppercaseType { found: "FEAT".to_string() },
+    ],
+    suggested_fix: Some("feat: add login".to_string()),
+}
+```
+
+**Example** — title `"Add login functionality"` (plain prose):
+
+```rust
+TitleDiagnosis {
+    issues: vec![TitleIssue::NoTypePrefix],
+    suggested_fix: None,   // no fix can be inferred
+}
+```
+
+##### `TitleValidationResult`
+
+Returned by `check_pr_title()` and `MergeWarden::check_title()`.  Combines the
+pass/fail/bypass outcome with the optional structured diagnosis.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TitleValidationResult {
+    /// The underlying validation outcome (valid, invalid, or bypassed).
+    pub validation: ValidationResult,
+
+    /// Present only when the title is **invalid and not bypassed**.
+    /// `None` when the title is valid or when validation was bypassed.
+    pub diagnosis: Option<TitleDiagnosis>,
+}
+```
+
+Delegation methods forward to the inner `ValidationResult` so existing call sites do
+not need to pattern-match on `validation` directly:
+
+| Method | Returns | Forwards to |
+|--------|---------|-------------|
+| `is_valid()` | `bool` | `ValidationResult::is_valid()` |
+| `was_bypassed()` | `bool` | `ValidationResult::was_bypassed()` |
+| `bypass_info()` | `Option<&BypassInfo>` | `ValidationResult::bypass_info()` |
+
+When `communicate_pr_title_validity_status()` builds the PR comment it:
+
+1. Iterates `diagnosis.issues` and calls `format_title_issue(issue)` on each to produce
+   one human-readable bullet per violation.
+2. If `diagnosis.suggested_fix` is `Some`, appends `` \nSuggested fix: `<fix>` ``.
+3. Always appends the general format reminder (supported types, expected format, link to
+   the Conventional Commits specification).
 
 ### Work Item Reference Rule
 

--- a/docs/spec/design/validation-engine.md
+++ b/docs/spec/design/validation-engine.md
@@ -3,6 +3,18 @@
 **Version:** 1.1
 **Last Updated:** April 10, 2026
 
+> **Note:** The detailed `ValidationRule` trait, `ValidationContext`, `RuleRegistry`, and
+> `TitleValidationRule` sections below describe the **target / aspirational architecture**.
+> They have not yet been implemented. The current implementation lives in
+> `crates/core/src/lib.rs` (`MergeWarden::check_title` /
+> `communicate_pr_title_validity_status`) and `crates/core/src/checks.rs`
+> (`check_pr_title`, `diagnose_pr_title`, `TitleIssue`, `TitleDiagnosis`,
+> `TitleValidationResult`).  The types `TitleFormat::ConventionalCommits`,
+> `DEFAULT_ALLOWED_TYPES`, `context.configuration.policies`, and `TitleValidationRule`
+> do not exist in the current codebase.  Per-issue human-readable messages are produced
+> by `<TitleIssue as std::fmt::Display>` in `checks.rs`, not by a standalone
+> `format_title_issue` function.
+
 ## Overview
 
 The validation engine is the core component responsible for evaluating pull requests against configured rules and policies. It provides an extensible framework for implementing validation rules, executing them efficiently, and collecting comprehensive results.


### PR DESCRIPTION
Replaces the single hardcoded "title does not follow conventional commit format" comment with per-violation, structured diagnostics that tell authors exactly what is wrong and, where possible, what to write instead.

## What Changed
- `crates/core/src/checks.rs`: new public types `TitleIssue` (9 variants), `TitleDiagnosis`, and `TitleValidationResult`; new public function `diagnose_pr_title()` that classifies each violation; `check_pr_title()` return type changed from `ValidationResult` to `TitleValidationResult`; private helpers `build_suggested_fix`, `check_colon_issues`, and `check_scope` extracted to keep line counts within limits.
- `crates/core/src/lib.rs`: `MergeWarden::check_title()` and `communicate_pr_title_validity_status()` updated to use `TitleValidationResult`; the posted PR comment now includes one actionable bullet per `TitleIssue` and a `Suggested fix:` line when a corrected title can be inferred; new private `format_title_issue()` function maps each variant to a prose sentence.
- `crates/core/src/check_tests.rs`: 40 new unit tests covering type construction, all 9 issue variants, all 7 typo-map entries, compound cases, and boundary inputs.
- `crates/core/src/lib_tests.rs`: 8 integration tests that exercise `process_pull_request()` end-to-end and assert specific phrases appear in the posted comment for each issue category.
- `docs/spec/design/validation-engine.md`: updated to v1.1 with definitions, examples, and synonym table for all new types; `TitleValidationRule.validate()` pseudocode updated to reflect the diagnosis-aware comment flow.

## Why
Previously, when merge_warden rejected a PR title, it posted a generic format-reminder comment. Authors had to compare their title against the full Conventional Commits specification themselves to find the mistake. Common errors such as wrong case (`FEAT`), a missing space after the colon (`feat:fix`), or a known synonym (`feature:` instead of `feat:`) were all reported identically.

The new diagnostic path identifies the specific structural problem, explains it in plain English, and in most cases supplies a corrected title string — reducing back-and-forth between authors and reviewers.

## How
`diagnose_pr_title()` works as a sequential detector: it trims leading whitespace, extracts the type token, checks it against `VALID_PR_TYPES` and a seven-entry `TYPE_TYPO_MAP`, then inspects scope validity, colon placement, and description presence. Issues accumulate in a `Vec<TitleIssue>` so that multiple simultaneous problems (e.g. leading whitespace *and* uppercase type) are all reported. `build_suggested_fix()` applies corrections in place when every detected issue is mechanically reversible; it returns `None` for unresolvable cases such as `NoTypePrefix` or `EmptyDescription`.

`communicate_pr_title_validity_status()` iterates `diagnosis.issues`, calls `format_title_issue()` for each to produce a prose bullet, appends the suggested fix when present, and appends the existing general format reminder. The `TITLE_COMMENT_MARKER` idempotency guard is unchanged.

## Testing Evidence
- **Test Coverage:** 48 new tests added (40 unit in `check_tests.rs`, 8 integration in `lib_tests.rs`); all 9 `TitleIssue` variants, all 7 typo-map entries, compound cases, boundary inputs, and end-to-end comment content verified.
- **Test Results:** 343 unit tests and 57 doc tests — all passing. No regressions.
- **Manual Testing:** Confirmed `cargo clippy -- -W clippy::pedantic` clean on all changed files.

## Reviewer Guidance
- The public API surface of `checks.rs` is extended (three new types + one new function); downstream crates or integration tests that pattern-match on `ValidationResult` from `check_pr_title` will need updating — none exist outside `core` in this repo.
- `TitleValidationResult` delegates `is_valid()`, `was_bypassed()`, and `bypass_info()` to the inner `ValidationResult`; call sites in `lib.rs` are unchanged except for the parameter type of `communicate_pr_title_validity_status`.
- The `enforce_title_convention = false` path still produces `TitleValidationResult { validation: valid(), diagnosis: None }` — no comment is posted (verified by test 5.8).
- The bypass path sets `diagnosis: None`; a bypass notification comment is posted via the existing bypass branch (unchanged).
```