### PR TITLE
fix(ci): update Docker action SHAs to valid pinned commits

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -116,17 +116,17 @@ jobs:
             --notes "${{ steps.extract_notes.outputs.notes }}"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@74a5d142397b4b9d50af0c81c7e39e5d5f800a2f # v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU (for multi-arch builds)
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff2c88cc4d47b1ae5e7 # v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232d2 # v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push container image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5


### PR DESCRIPTION
The three Docker actions were pinned to invalid/corrupted commit SHAs causing the publish-release workflow to fail at the action resolution step. Updated to the correct verified commit SHAs for the latest v3 releases:
- docker/login-action v3.7.0
- docker/setup-qemu-action v3.7.0
- docker/setup-buildx-action v3.12.0
