### PR TITLE
fix(ci): restructure release workflow and rename container image

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
 
       - name: Install cargo binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # main
 
       - name: Install Conventional Commits Next Version
         run: cargo binstall conventional_commits_next_version --no-confirm
@@ -68,7 +68,10 @@ jobs:
     name: Build CLI - ${{ matrix.target }}
     needs: determine-version
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -149,6 +152,7 @@ jobs:
     name: Publish Release
     needs: [determine-version, build-cli]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Generate GitHub App token
@@ -172,7 +176,7 @@ jobs:
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
 
       - name: Install cargo binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # main
 
       - name: Install git-cliff
         run: cargo binstall git-cliff --no-confirm
@@ -194,18 +198,10 @@ jobs:
           git push origin "${RELEASE_VERSION}"
 
       - name: Extract Release Notes
-        id: extract_notes
         run: |
           RELEASE_VERSION="${{ needs.determine-version.outputs.release_version }}"
           echo "Extracting notes for tag ${RELEASE_VERSION}"
-          # Use git-cliff to get notes for the specific tag, stripping headers/footers
-          # Use a delimiter for multiline output handling in GitHub Actions
-          delimiter="$(openssl rand -hex 8)"
-          {
-            echo "notes<<${delimiter}"
-            git-cliff --tag "${RELEASE_VERSION}" --strip all
-            echo "${delimiter}"
-          } >> "${GITHUB_OUTPUT}"
+          git-cliff --tag "${RELEASE_VERSION}" --strip all > /tmp/release-notes.md
 
       - name: Download CLI artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -213,6 +209,16 @@ jobs:
           pattern: cli-*
           path: artifacts
           merge-multiple: true
+
+      - name: Verify CLI artifacts
+        run: |
+          count=$(ls artifacts/ | wc -l)
+          echo "Artifacts found: ${count}"
+          if [[ "${count}" -ne 3 ]]; then
+            echo "ERROR: Expected 3 artifacts (linux-gnu, linux-musl, windows), found ${count}"
+            ls -la artifacts/
+            exit 1
+          fi
 
       - name: Create GitHub Release
         env:
@@ -222,7 +228,7 @@ jobs:
           echo "Creating GitHub Release for ${RELEASE_VERSION}"
           gh release create "${RELEASE_VERSION}" \
             --title "Release ${RELEASE_VERSION}" \
-            --notes "${{ steps.extract_notes.outputs.notes }}" \
+            --notes-file /tmp/release-notes.md \
             artifacts/*
 
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,13 +13,142 @@ permissions:
   packages: write # To push container images to GHCR
 
 jobs:
-  publish-release:
-    name: Publish Release
+  determine-version:
+    name: Determine Release Version
     # Only run if the PR was merged and the head branch matches release/*
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     outputs:
       release_version: ${{ steps.get_version.outputs.RELEASE_VERSION }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Checkout the base branch (master) after the merge
+          ref: ${{ github.event.pull_request.base.ref }}
+          # Fetch all history needed for conventional_commits_next_version
+          fetch-depth: 0
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
+
+      - name: Install cargo binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install Conventional Commits Next Version
+        run: cargo binstall conventional_commits_next_version --no-confirm
+
+      - name: Get release version
+        id: get_version
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0)
+          LAST_COMMIT=$(git rev-parse "${LAST_TAG}")
+          RELEASE_VERSION=$(conventional_commits_next_version --from-version "${LAST_TAG}" --calculation-mode Batch "${LAST_COMMIT}")
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "The release version is: ${RELEASE_VERSION}"
+
+      - name: Assert calculated version matches release branch
+        env:
+          RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
+          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          BRANCH_VERSION="${BRANCH_REF#release/}"
+          if [[ "${RELEASE_VERSION}" != "${BRANCH_VERSION}" ]]; then
+            echo "ERROR: Calculated version (${RELEASE_VERSION}) does not match branch version (${BRANCH_VERSION})"
+            echo "Branch: ${BRANCH_REF}"
+            echo "This usually means commits made after the release branch was cut have changed the calculated version."
+            exit 1
+          fi
+          echo "Version assertion passed: ${RELEASE_VERSION} matches branch ${BRANCH_REF}"
+
+  build-cli:
+    name: Build CLI - ${{ matrix.target }}
+    needs: determine-version
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-22.04
+          - target: x86_64-pc-windows-msvc
+            os: windows-2022
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: taiki-e/setup-cross-toolchain-action@0123528f956f923e7a476f4cc04882bc005e7c89 # v1
+        with:
+          target: ${{ matrix.target }}
+        if: startsWith(matrix.os, 'ubuntu') && !contains(matrix.target, '-musl')
+
+      - uses: taiki-e/install-action@92f69c195229fe62d58b4d697ab4bc75def98e76 # v2
+        with:
+          tool: cross
+        if: contains(matrix.target, '-musl')
+
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
+
+      - name: Set static CRT for Windows
+        run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
+        shell: bash
+        if: endsWith(matrix.target, 'windows-msvc')
+
+      - name: Build CLI binary (musl via cross)
+        run: cross build --release --target ${{ matrix.target }} --bin merge-warden
+        if: contains(matrix.target, '-musl')
+
+      - name: Build CLI binary
+        run: cargo build --release --target ${{ matrix.target }} --bin merge-warden
+        if: "!contains(matrix.target, '-musl')"
+
+      - name: Package binary (Unix)
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.determine-version.outputs.release_version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          ARCHIVE="merge-warden-${RELEASE_VERSION}-${TARGET}.tar.gz"
+          cp "target/${TARGET}/release/merge-warden" merge-warden
+          tar czf "${ARCHIVE}" merge-warden
+          echo "ARCHIVE=${ARCHIVE}" >> "${GITHUB_ENV}"
+
+      - name: Package binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ needs.determine-version.outputs.release_version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          $archive = "merge-warden-$env:RELEASE_VERSION-$env:TARGET.zip"
+          Copy-Item "target\$env:TARGET\release\merge-warden.exe" merge-warden.exe
+          Compress-Archive -Path merge-warden.exe -DestinationPath $archive
+          "ARCHIVE=$archive" >> $env:GITHUB_ENV
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cli-${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+          retention-days: 1
+
+  publish-release:
+    name: Publish Release
+    needs: [determine-version, build-cli]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Generate GitHub App token
@@ -45,14 +174,8 @@ jobs:
       - name: Install cargo binstall
         uses: cargo-bins/cargo-binstall@main
 
-      - name: Install Conventional Commits Next Version
-        run: cargo install conventional_commits_next_version
-
       - name: Install git-cliff
-        run: cargo install git-cliff
-
-      - name: Install cargo typos
-        run: cargo install typos-cli
+        run: cargo binstall git-cliff --no-confirm
 
       # Recommended as per: https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token
       - name: Configure Git user
@@ -60,43 +183,20 @@ jobs:
           git config user.name "releaser[bot]"
           git config user.email "releaser[bot]@users.noreply.github.com"
 
-      - name: Get release version from Cargo.toml
-        id: get_version
-        run: |
-          LAST_TAG=$(git describe --tags --abbrev=0)
-          LAST_COMMIT=$(git rev-parse "${LAST_TAG}")
-          RELEASE_VERSION=$(conventional_commits_next_version --from-version "${LAST_TAG}" --calculation-mode Batch "${LAST_COMMIT}")
-          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
-          echo "The release version is: ${RELEASE_VERSION}"
-
-      - name: Assert calculated version matches release branch
-        env:
-          RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
-          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          BRANCH_VERSION="${BRANCH_REF#release/}"
-          if [[ "${RELEASE_VERSION}" != "${BRANCH_VERSION}" ]]; then
-            echo "ERROR: Calculated version (${RELEASE_VERSION}) does not match branch version (${BRANCH_VERSION})"
-            echo "Branch: ${BRANCH_REF}"
-            echo "This usually means commits made after the release branch was cut have changed the calculated version."
-            exit 1
-          fi
-          echo "Version assertion passed: ${RELEASE_VERSION} matches branch ${BRANCH_REF}"
-
       - name: Set up git remote to use app token
         run: |
           git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
 
       - name: Create and Push Git Tag
         run: |
-          RELEASE_VERSION="${{ steps.get_version.outputs.RELEASE_VERSION }}"
+          RELEASE_VERSION="${{ needs.determine-version.outputs.release_version }}"
           git tag -a "${RELEASE_VERSION}" -m "Release ${RELEASE_VERSION}"
           git push origin "${RELEASE_VERSION}"
 
       - name: Extract Release Notes
         id: extract_notes
         run: |
-          RELEASE_VERSION="${{ steps.get_version.outputs.RELEASE_VERSION }}"
+          RELEASE_VERSION="${{ needs.determine-version.outputs.release_version }}"
           echo "Extracting notes for tag ${RELEASE_VERSION}"
           # Use git-cliff to get notes for the specific tag, stripping headers/footers
           # Use a delimiter for multiline output handling in GitHub Actions
@@ -107,15 +207,23 @@ jobs:
             echo "${delimiter}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Download CLI artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: cli-*
+          path: artifacts
+          merge-multiple: true
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          RELEASE_VERSION="${{ steps.get_version.outputs.RELEASE_VERSION }}"
+          RELEASE_VERSION="${{ needs.determine-version.outputs.release_version }}"
           echo "Creating GitHub Release for ${RELEASE_VERSION}"
           gh release create "${RELEASE_VERSION}" \
             --title "Release ${RELEASE_VERSION}" \
-            --notes "${{ steps.extract_notes.outputs.notes }}"
+            --notes "${{ steps.extract_notes.outputs.notes }}" \
+            artifacts/*
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -138,58 +246,5 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/pvandervelde/merge_warden/server:latest
-            ghcr.io/pvandervelde/merge_warden/server:${{ steps.get_version.outputs.RELEASE_VERSION }}
-
-  publish-cli:
-    name: Publish CLI - ${{ matrix.target }}
-    needs: publish-release
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: write
-    strategy:
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-22.04
-          - target: x86_64-pc-windows-msvc
-            os: windows-2022
-    timeout-minutes: 60
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ needs.publish-release.outputs.release_version }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - uses: taiki-e/setup-cross-toolchain-action@0123528f956f923e7a476f4cc04882bc005e7c89 # v1
-        with:
-          target: ${{ matrix.target }}
-        if: startsWith(matrix.os, 'ubuntu') && !contains(matrix.target, '-musl')
-
-      - uses: taiki-e/install-action@92f69c195229fe62d58b4d697ab4bc75def98e76 # v2
-        with:
-          tool: cross
-        if: contains(matrix.target, '-musl')
-
-      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
-
-      - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
-        shell: bash
-        if: endsWith(matrix.target, 'windows-msvc')
-
-      - uses: taiki-e/upload-rust-binary-action@3962470d6e7f1993108411bc3f75a135ec67fc8c # v1
-        env:
-          GITHUB_REF: refs/tags/${{ needs.publish-release.outputs.release_version }}
-        with:
-          bin: merge-warden
-          target: ${{ matrix.target }}
-          tar: unix
-          zip: windows
-          token: ${{ secrets.GITHUB_TOKEN }}
+            ghcr.io/pvandervelde/merge-warden-server:latest
+            ghcr.io/pvandervelde/merge-warden-server:${{ needs.determine-version.outputs.release_version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -212,11 +212,11 @@ jobs:
 
       - name: Verify CLI artifacts
         run: |
-          count=$(ls artifacts/ | wc -l)
+          count=$(find artifacts/ -maxdepth 1 -type f | wc -l)
           echo "Artifacts found: ${count}"
           if [[ "${count}" -ne 3 ]]; then
             echo "ERROR: Expected 3 artifacts (linux-gnu, linux-musl, windows), found ${count}"
-            ls -la artifacts/
+            find artifacts/ -maxdepth 1 -type f
             exit 1
           fi
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -6,8 +6,8 @@ Registry (GHCR). The same image runs on any OCI-compatible container host.
 ## Container Image
 
 ```
-ghcr.io/pvandervelde/merge_warden/server:latest
-ghcr.io/pvandervelde/merge_warden/server:<version>
+ghcr.io/pvandervelde/merge-warden-server:latest
+ghcr.io/pvandervelde/merge-warden-server:<version>
 ```
 
 Images are built from `crates/server/Dockerfile` and published automatically on each
@@ -93,7 +93,7 @@ docker run --rm \
   -e GITHUB_APP_PRIVATE_KEY="$(cat /path/to/private-key.pem)" \
   -e GITHUB_WEBHOOK_SECRET=supersecret \
   -p 3000:3000 \
-  ghcr.io/pvandervelde/merge_warden/server:latest
+  ghcr.io/pvandervelde/merge-warden-server:latest
 ```
 
 Verify the server is healthy:

--- a/docs/deployment/aws/README.md
+++ b/docs/deployment/aws/README.md
@@ -40,7 +40,7 @@ aws secretsmanager create-secret \
   "containerDefinitions": [
     {
       "name": "merge-warden",
-      "image": "ghcr.io/pvandervelde/merge_warden/server:latest",
+      "image": "ghcr.io/pvandervelde/merge-warden-server:latest",
       "portMappings": [{ "containerPort": 3000 }],
       "secrets": [
         {

--- a/docs/deployment/azure/README.md
+++ b/docs/deployment/azure/README.md
@@ -38,7 +38,7 @@ az containerapp create \
   --name merge-warden \
   --resource-group rg-merge-warden \
   --environment cae-merge-warden \
-  --image ghcr.io/pvandervelde/merge_warden/server:latest \
+  --image ghcr.io/pvandervelde/merge-warden-server:latest \
   --target-port 3000 \
   --ingress external \
   --secrets \

--- a/docs/spec/design/containerisation.md
+++ b/docs/spec/design/containerisation.md
@@ -33,7 +33,7 @@ Registry (`ghcr.io`).
 - Configuration injected as environment variables or mounted config file
 - No Azure SDK dependencies in the binary for runtime secrets/config (Azure SDK deps
   are acceptable for optional local dev tooling)
-- Single `Dockerfile`, published to `ghcr.io/pvandervelde/merge_warden/server`
+- Single `Dockerfile`, published to `ghcr.io/pvandervelde/merge-warden-server`
 - CI pipeline builds and pushes the image on release
 
 ---
@@ -234,8 +234,8 @@ permissions:
     file: crates/server/Dockerfile
     push: true
     tags: |
-      ghcr.io/pvandervelde/merge_warden/server:latest
-      ghcr.io/pvandervelde/merge_warden/server:${{ steps.get_version.outputs.RELEASE_VERSION }}
+      ghcr.io/pvandervelde/merge-warden-server:latest
+      ghcr.io/pvandervelde/merge-warden-server:${{ needs.determine-version.outputs.release_version }}
 ```
 
 No changes are needed to `prepare-release.yml`.

--- a/docs/spec/operations/deployment.md
+++ b/docs/spec/operations/deployment.md
@@ -88,7 +88,7 @@ sequentially while different PRs may be processed in parallel.
 ```yaml
 services:
   merge-warden:
-    image: ghcr.io/pvandervelde/merge_warden_server:latest
+    image: ghcr.io/pvandervelde/merge-warden-server:latest
     environment:
       MERGE_WARDEN_RECEIVER_MODE: queue
       GITHUB_APP_ID: ${GITHUB_APP_ID}


### PR DESCRIPTION
Fixes the CLI binary publish failure from the last release and renames the server container image to a more distinct name.

## What Changed
- `publish-release.yml`: split into three sequential jobs — `determine-version` (compute and validate the semver), `build-cli` (matrix build for linux-gnu, linux-musl, windows-msvc; produces archived binaries as GitHub Actions artifacts), and `publish-release` (creates the tag, creates the GitHub Release with all CLI archives attached in one call, then builds and pushes the container image). Replaced `taiki-e/upload-rust-binary-action` with a manual `cargo build` + archive + `actions/upload-artifact` / `actions/download-artifact` + `gh release create artifacts/*` approach.
- Container image renamed from `ghcr.io/pvandervelde/merge_warden/server` to `ghcr.io/pvandervelde/merge-warden-server` in the workflow and all deployment documentation.

## Why
`taiki-e/upload-rust-binary-action` requires the triggering event to be a tag push (`refs/tags/…`). The workflow is triggered by a `pull_request: closed` event, so the action refused to run with: _"tag ref should start with 'refs/tags/': 'refs/heads/master'; this action only supports events from tag or release by default"_. An environment-variable override of `GITHUB_REF` at the step level does not bypass this check.

The container image name `merge_warden/server` used an intermediate path segment (`merge_warden/`) that made it look like a scoped sub-package rather than a top-level image, and used underscores inconsistently with container naming conventions.

## How
CLI binaries are now built in a parallel matrix job (`build-cli`) that runs after version determination but before the GitHub Release is created. Each target produces a `.tar.gz` (Linux) or `.zip` (Windows) and uploads it as a short-lived Actions artifact. The `publish-release` job downloads all three archives and passes them directly to `gh release create`, so every asset is attached atomically when the release is first created.

## Testing Evidence
- **Test Coverage:** No new unit tests; workflow correctness is validated by the next release run.
- **Test Results:** Not yet re-run end-to-end; the root cause (action event constraint) is definitively addressed by removing the action entirely.
- **Manual Testing:** Workflow YAML validated for syntax; `gh release create artifacts/*` glob pattern confirmed against GitHub CLI documentation.

## Reviewer Guidance
- Verify the `build-cli` matrix job checks out `github.event.pull_request.base.ref` (master after merge) rather than the release tag, since the tag does not exist yet at that point.
- Confirm `actions/download-artifact` with `merge-multiple: true` correctly merges all three `cli-*` artifacts into a flat `artifacts/` directory before the `gh release create` call.
- Container image rename is a breaking change for anyone pulling `ghcr.io/pvandervelde/merge_warden/server` — deployment docs have been updated, but external users will need to update their references.
- The `typos-cli` install step was removed from `publish-release`; confirm it is not needed at release time (it was used in the release commit flow, which no longer exists here).