### PR TITLE
feat(config): align ApplicationDefaults TOML keys with snake_case convention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,7 +2618,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merge-warden-integration-tests"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "merge_warden_cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "merge_warden_core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "merge_warden_developer_platforms"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "merge_warden_server"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -242,53 +242,35 @@ pub static WORK_ITEM_REGEX: &str = r"(?i)(fixes|closes|resolves|references|relat
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApplicationDefaults {
     /// Whether the pull request title should follow a convention
-    #[serde(
-        rename = "enforceTitleValidation",
-        default = "ApplicationDefaults::default_title_required"
-    )]
+    #[serde(default = "ApplicationDefaults::default_title_required")]
     pub enable_title_validation: bool,
 
     /// Default regex pattern for validating pull request titles
-    #[serde(
-        rename = "titlePattern",
-        default = "ApplicationDefaults::default_title_pattern"
-    )]
+    #[serde(default = "ApplicationDefaults::default_title_pattern")]
     pub default_title_pattern: String,
 
     /// Default label to apply when title validation fails
-    #[serde(
-        rename = "labelIfTitleInvalid",
-        default = "ApplicationDefaults::default_title_invalid_label"
-    )]
+    #[serde(default = "ApplicationDefaults::default_title_invalid_label")]
     pub default_invalid_title_label: Option<String>,
 
     /// Whether work item reference validation is enabled by default
-    #[serde(
-        rename = "enforceWorkItemValidation",
-        default = "ApplicationDefaults::default_work_item_required"
-    )]
+    #[serde(default = "ApplicationDefaults::default_work_item_required")]
     pub enable_work_item_validation: bool,
 
     /// Default regex pattern for validating work item references
-    #[serde(
-        rename = "workItemPattern",
-        default = "ApplicationDefaults::default_work_item_pattern"
-    )]
+    #[serde(default = "ApplicationDefaults::default_work_item_pattern")]
     pub default_work_item_pattern: String,
 
     /// Default label to apply when work item reference is missing
-    #[serde(
-        rename = "labelIfWorkItemMissing",
-        default = "ApplicationDefaults::default_work_item_missing_label"
-    )]
+    #[serde(default = "ApplicationDefaults::default_work_item_missing_label")]
     pub default_missing_work_item_label: Option<String>,
 
     /// Bypass rules for allowing specific users to skip validation
-    #[serde(rename = "bypassRules", default)]
+    #[serde(default)]
     pub bypass_rules: BypassRules,
 
     /// Configuration for PR size checking
-    #[serde(rename = "prSize", default)]
+    #[serde(default)]
     pub pr_size_check: PrSizeCheckConfig,
 
     /// Configuration for change type label detection
@@ -296,11 +278,11 @@ pub struct ApplicationDefaults {
     pub change_type_labels: ChangeTypeLabelConfig,
 
     /// Application-level defaults for WIP detection and blocking
-    #[serde(rename = "wip", default)]
+    #[serde(default)]
     pub wip_check: WipCheckConfig,
 
     /// Application-level defaults for state-based PR lifecycle labels
-    #[serde(rename = "prState", default)]
+    #[serde(default)]
     pub pr_state_labels: PrStateLabelsConfig,
 }
 

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -729,10 +729,10 @@ fn test_application_defaults_bypass_rules_serialization() {
     let parsed: serde_json::Value =
         serde_json::from_str(&serialized).expect("Failed to parse JSON");
 
-    assert_eq!(parsed["enforceTitleValidation"], true);
-    assert_eq!(parsed["bypassRules"]["title_convention"]["enabled"], true);
+    assert_eq!(parsed["enable_title_validation"], true);
+    assert_eq!(parsed["bypass_rules"]["title_convention"]["enabled"], true);
     assert_eq!(
-        parsed["bypassRules"]["title_convention"]["users"][0],
+        parsed["bypass_rules"]["title_convention"]["users"][0],
         "admin"
     );
 }
@@ -1290,5 +1290,107 @@ sync_project_from_issue = true
     assert!(
         validation.issue_propagation.sync_project_from_issue,
         "to_validation_config should forward sync_project_from_issue = true"
+    );
+}
+
+// ── ApplicationDefaults snake_case TOML key tests ────────────────────────────
+
+#[test]
+fn test_application_defaults_new_field_names_round_trip_toml() {
+    // Round-trip using the new snake_case TOML keys (post-rename).
+    let toml_input = r#"
+enable_title_validation = true
+default_title_pattern = "my-title-pattern"
+default_invalid_title_label = "bad-title"
+enable_work_item_validation = true
+default_work_item_pattern = "my-work-item-pattern"
+default_missing_work_item_label = "missing-work-item"
+"#;
+
+    let defaults: ApplicationDefaults =
+        toml::from_str(toml_input).expect("Should deserialize from snake_case keys");
+
+    assert!(defaults.enable_title_validation);
+    assert_eq!(defaults.default_title_pattern, "my-title-pattern");
+    assert_eq!(
+        defaults.default_invalid_title_label,
+        Some("bad-title".to_string())
+    );
+    assert!(defaults.enable_work_item_validation);
+    assert_eq!(defaults.default_work_item_pattern, "my-work-item-pattern");
+    assert_eq!(
+        defaults.default_missing_work_item_label,
+        Some("missing-work-item".to_string())
+    );
+
+    // Serialize back to TOML and verify snake_case keys are present.
+    let serialized = toml::to_string(&defaults).expect("Should serialize");
+    assert!(
+        serialized.contains("enable_title_validation"),
+        "Serialized TOML must use 'enable_title_validation', got:\n{serialized}"
+    );
+    assert!(
+        !serialized.contains("enforceTitleValidation"),
+        "Serialized TOML must NOT contain legacy key 'enforceTitleValidation'"
+    );
+    assert!(
+        serialized.contains("enable_work_item_validation"),
+        "Serialized TOML must use 'enable_work_item_validation'"
+    );
+    assert!(
+        !serialized.contains("enforceWorkItemValidation"),
+        "Serialized TOML must NOT contain legacy key 'enforceWorkItemValidation'"
+    );
+
+    // Deserialize again to confirm full round-trip correctness.
+    let roundtripped: ApplicationDefaults =
+        toml::from_str(&serialized).expect("Should deserialize after serialization");
+    assert_eq!(
+        roundtripped.enable_title_validation,
+        defaults.enable_title_validation
+    );
+    assert_eq!(
+        roundtripped.default_title_pattern,
+        defaults.default_title_pattern
+    );
+    assert_eq!(
+        roundtripped.default_invalid_title_label,
+        defaults.default_invalid_title_label
+    );
+    assert_eq!(
+        roundtripped.enable_work_item_validation,
+        defaults.enable_work_item_validation
+    );
+    assert_eq!(
+        roundtripped.default_work_item_pattern,
+        defaults.default_work_item_pattern
+    );
+    assert_eq!(
+        roundtripped.default_missing_work_item_label,
+        defaults.default_missing_work_item_label
+    );
+}
+
+#[test]
+fn test_application_defaults_camelcase_keys_no_longer_deserialize() {
+    // After the rename, camelCase keys in TOML should be ignored (serde skips unknown fields),
+    // so the fields fall back to their #[serde(default)] values.
+    let toml_camel = r#"
+enforceTitleValidation = true
+titlePattern = "some-pattern"
+"#;
+
+    let defaults: ApplicationDefaults =
+        toml::from_str(toml_camel).expect("Should succeed (unknown keys are ignored)");
+
+    // Because the keys are now unknown to serde, defaults apply.
+    assert!(
+        !defaults.enable_title_validation,
+        "enforceTitleValidation is no longer a recognised key; default (false) must be used"
+    );
+    assert_eq!(
+        defaults.default_title_pattern,
+        CONVENTIONAL_COMMIT_REGEX.to_string(),
+        "titlePattern is no longer a recognised key; default pattern must be used"
     );
 }

--- a/crates/server/src/config_tests.rs
+++ b/crates/server/src/config_tests.rs
@@ -426,7 +426,7 @@ fn load_config_reads_application_defaults_from_toml_file() {
     // Write a minimal TOML file with one overridden field.
     let mut path = std::env::temp_dir();
     path.push("merge_warden_server_load_config_test.toml");
-    std::fs::write(&path, "[policies]\nenforceTitleValidation = true\n").unwrap();
+    std::fs::write(&path, "[policies]\nenable_title_validation = true\n").unwrap();
 
     let _env = EnvGuard::prepare(
         &[("MERGE_WARDEN_CONFIG_FILE", path.to_str().unwrap())],
@@ -443,7 +443,7 @@ fn load_config_reads_application_defaults_from_toml_file() {
     assert!(r.is_ok(), "{:?}", r);
     assert!(
         r.unwrap().application_defaults.enable_title_validation,
-        "Expected enforceTitleValidation = true from TOML"
+        "Expected enable_title_validation = true from TOML"
     );
 }
 

--- a/docs/user/explanation/config-precedence.md
+++ b/docs/user/explanation/config-precedence.md
@@ -53,7 +53,7 @@ See [Per-repository configuration schema](../reference/per-repo-config.md).
 
 ## Field-level override
 
-Precedence operates at the field level, not the file level. If `enforceTitleValidation` is
+Precedence operates at the field level, not the file level. If `enable_title_validation` is
 set in the application config but `.github/merge-warden.toml` does not include a
 `[policies.pullRequests.prTitle]` section, the application-level setting applies.
 
@@ -68,8 +68,8 @@ Assume the application config sets:
 
 ```toml
 [policies]
-enforceTitleValidation    = true
-enforceWorkItemValidation = true
+enable_title_validation      = true
+enable_work_item_validation  = true
 ```
 
 And a repository's `.github/merge-warden.toml` contains:

--- a/docs/user/explanation/two-config-files.md
+++ b/docs/user/explanation/two-config-files.md
@@ -18,7 +18,7 @@ common source of confusion. This page explains why they exist and how they diffe
 | **Scope** | All repositories on the server | One specific repository |
 | **Who controls it** | Operator (platform team) | Repository maintainer |
 | **Schema** | `ApplicationDefaults` | `policies.*` |
-| **Example field** | `enforceTitleValidation` | `[prTitle] required` |
+| **Example field** | `enable_title_validation` | `[prTitle] required` |
 
 ---
 
@@ -28,7 +28,8 @@ The two files were designed for different audiences with different mental models
 
 **Operators** think in terms of broad organisational defaults: "I want all repositories to
 have title validation enabled unless a team explicitly opts out." The `ApplicationDefaults`
-schema reflects this with simple boolean flags at the top level.
+schema reflects this with simple boolean fields at the top level, using snake_case names
+consistent with the per-repository config.
 
 **Repository maintainers** think in terms of specific policies with detailed settings: "I
 want title validation with this pattern and this failure label." The `policies.*` schema
@@ -54,14 +55,16 @@ Always use:
 
 ### Field name mapping
 
+Both files now use snake_case field names. The structural differences remain:
+
 | Application config field | Per-repo equivalent |
 | :--- | :--- |
-| `enforceTitleValidation` | `[prTitle] required` |
-| `enforceWorkItemValidation` | `[workItem] required` |
-| `titlePattern` | `[prTitle] pattern` |
-| `labelIfTitleInvalid` | `[prTitle] label_if_missing` |
-| `workItemPattern` | `[workItem] pattern` |
-| `labelIfWorkItemMissing` | `[workItem] label_if_missing` |
+| `enable_title_validation` | `[prTitle] required` |
+| `enable_work_item_validation` | `[workItem] required` |
+| `default_title_pattern` | `[prTitle] pattern` |
+| `default_invalid_title_label` | `[prTitle] label_if_missing` |
+| `default_work_item_pattern` | `[workItem] pattern` |
+| `default_missing_work_item_label` | `[workItem] label_if_missing` |
 
 For the complete mapping, see [Application configuration schema](../reference/app-config.md).
 

--- a/docs/user/how-to/set-app-level-defaults.md
+++ b/docs/user/how-to/set-app-level-defaults.md
@@ -67,12 +67,12 @@ per-repository config. The most common ones:
 
 | Application config field | Per-repo equivalent | Purpose |
 | :--- | :--- | :--- |
-| `enforceTitleValidation` | `required` (under `prTitle`) | Enable title validation |
-| `titlePattern` | `pattern` (under `prTitle`) | Title regex |
-| `labelIfTitleInvalid` | `label_if_missing` (under `prTitle`) | Label when title invalid |
-| `enforceWorkItemValidation` | `required` (under `workItem`) | Enable work item validation |
-| `workItemPattern` | `pattern` (under `workItem`) | Work item reference regex |
-| `labelIfWorkItemMissing` | `label_if_missing` (under `workItem`) | Label when work item missing |
+| `enable_title_validation` | `required` (under `prTitle`) | Enable title validation |
+| `default_title_pattern` | `pattern` (under `prTitle`) | Title regex |
+| `default_invalid_title_label` | `label_if_missing` (under `prTitle`) | Label when title invalid |
+| `enable_work_item_validation` | `required` (under `workItem`) | Enable work item validation |
+| `default_work_item_pattern` | `pattern` (under `workItem`) | Work item reference regex |
+| `default_missing_work_item_label` | `label_if_missing` (under `workItem`) | Label when work item missing |
 
 For the complete field list, see [Application configuration schema](../reference/app-config.md).
 

--- a/docs/user/reference/app-config.md
+++ b/docs/user/reference/app-config.md
@@ -12,9 +12,9 @@ The application-level configuration file is loaded by the server via the
 Per-repository `.github/merge-warden.toml` files take precedence over these defaults.
 See [Configuration precedence](../explanation/config-precedence.md).
 
-> **Important:** This file uses different field names to the per-repository config. The
-> table in each section below links the equivalent per-repo field. Pointing
-> `MERGE_WARDEN_CONFIG_FILE` at a per-repo sample file will silently produce no enforcement.
+> **Note:** This file uses the same snake_case field name convention as the per-repository
+> config. Pointing `MERGE_WARDEN_CONFIG_FILE` at a per-repo sample file will silently
+> produce no enforcement because the top-level structures differ.
 
 See [`samples/app-config.sample.toml`](https://github.com/pvandervelde/merge_warden/blob/master/samples/app-config.sample.toml)
 for a fully annotated example.
@@ -27,16 +27,16 @@ Top-level policy defaults.
 
 | Field | Type | Default | Per-repo equivalent |
 | :--- | :--- | :--- | :--- |
-| `enforceTitleValidation` | bool | `false` | `[prTitle] required` |
-| `titlePattern` | string | *(conventional commits)* | `[prTitle] pattern` |
-| `labelIfTitleInvalid` | string | *(none)* | `[prTitle] label_if_missing` |
-| `enforceWorkItemValidation` | bool | `false` | `[workItem] required` |
-| `workItemPattern` | string | *(GitHub issue patterns)* | `[workItem] pattern` |
-| `labelIfWorkItemMissing` | string | *(none)* | `[workItem] label_if_missing` |
+| `enable_title_validation` | bool | `false` | `[prTitle] required` |
+| `default_title_pattern` | string | *(conventional commits)* | `[prTitle] pattern` |
+| `default_invalid_title_label` | string | *(none)* | `[prTitle] label_if_missing` |
+| `enable_work_item_validation` | bool | `false` | `[workItem] required` |
+| `default_work_item_pattern` | string | *(GitHub issue patterns)* | `[workItem] pattern` |
+| `default_missing_work_item_label` | string | *(none)* | `[workItem] label_if_missing` |
 
 ---
 
-## `[policies.prSize]`
+## `[policies.pr_size_check]`
 
 | Field | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
@@ -48,7 +48,7 @@ Top-level policy defaults.
 
 ---
 
-## `[policies.wip]`
+## `[policies.wip_check]`
 
 | Field | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
@@ -59,7 +59,7 @@ Top-level policy defaults.
 
 ---
 
-## `[policies.prState]`
+## `[policies.pr_state_labels]`
 
 | Field | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
@@ -83,7 +83,7 @@ for details.
 
 ---
 
-## `[policies.bypassRules.*]`
+## `[policies.bypass_rules.*]`
 
 Three bypass sections are available: `title_convention`, `work_items`, `size`.
 
@@ -103,31 +103,31 @@ overridden by per-repo configs.
 
 ```toml
 [policies]
-enforceTitleValidation    = true
-labelIfTitleInvalid       = "pr-issue: invalid-title-format"
+enable_title_validation       = true
+default_invalid_title_label   = "pr-issue: invalid-title-format"
 
-enforceWorkItemValidation = true
-labelIfWorkItemMissing    = "pr-issue: missing-work-item"
+enable_work_item_validation      = true
+default_missing_work_item_label  = "pr-issue: missing-work-item"
 
-[policies.prSize]
+[policies.pr_size_check]
 enabled          = false
 fail_on_oversized = false
 label_prefix     = "size/"
 add_comment      = true
 
-[policies.wip]
+[policies.wip_check]
 enforce_wip_blocking  = true
 wip_label             = "WIP"
 wip_title_patterns    = ["WIP", "wip:", "[wip]", "draft:", "Draft:"]
 wip_description_patterns = []
 
-[policies.prState]
+[policies.pr_state_labels]
 enabled        = true
 draft_label    = "status: draft"
 review_label   = "status: in-review"
 approved_label = "status: approved"
 
-[policies.bypassRules.title_convention]
+[policies.bypass_rules.title_convention]
 enabled = false
 users   = []
 

--- a/docs/user/reference/app-config.md
+++ b/docs/user/reference/app-config.md
@@ -131,11 +131,11 @@ approved_label = "status: approved"
 enabled = false
 users   = []
 
-[policies.bypassRules.work_items]
+[policies.bypass_rules.work_items]
 enabled = false
 users   = []
 
-[policies.bypassRules.size]
+[policies.bypass_rules.size]
 enabled = false
 users   = []
 ```

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -186,7 +186,7 @@ port = 3000
 
 [policies]
 # Application-level policy defaults — see app-config reference
-enforceTitleValidation = true
+enable_title_validation = true
 ```
 
 ---

--- a/samples/README.md
+++ b/samples/README.md
@@ -16,11 +16,11 @@ This file is loaded by the server via the `MERGE_WARDEN_CONFIG_FILE` environment
 variable. It defines the **application-level** policy defaults that apply to every
 repository handled by this server instance.
 
-> **Important:** This file uses different field names to `merge-warden.sample.toml`.
-> `MERGE_WARDEN_CONFIG_FILE` expects `ApplicationDefaults` fields (e.g.
-> `enforceTitleValidation`, `titlePattern`). The per-repo config uses a different
-> structure (`[policies.pullRequests.prTitle]`). Pointing `MERGE_WARDEN_CONFIG_FILE`
-> at the per-repo sample will silently produce no enforcement.
+> **Note:** This file uses the same snake_case convention as `merge-warden.sample.toml`
+> but a different top-level structure. `MERGE_WARDEN_CONFIG_FILE` expects `ApplicationDefaults`
+> fields (e.g. `enable_title_validation`). The per-repo config uses a different structure
+> (`[policies.pullRequests.prTitle]`). Pointing `MERGE_WARDEN_CONFIG_FILE` at the per-repo
+> sample will silently produce no enforcement.
 
 Pass it to `run-local.ps1` with:
 

--- a/samples/app-config.sample.toml
+++ b/samples/app-config.sample.toml
@@ -5,25 +5,24 @@
 # by this server instance.  Values here are used when a repository has no
 # .github/merge-warden.toml of its own, or when a per-repo file omits a field.
 #
-# Note: this file uses different field names to the per-repo config
-# (merge-warden.sample.toml).  These names map to the ApplicationDefaults
-# struct in the Rust codebase.
+# Field names here use the same snake_case convention as the per-repo config
+# (merge-warden.sample.toml).
 
 [policies]
 # Enforce conventional-commit title format for all repositories by default.
 # The pattern below is the built-in conventional commit regex; uncomment and
 # edit to override.
-enforceTitleValidation = true
-# titlePattern = "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9_-]+\\))?!?: .+"
-labelIfTitleInvalid = "pr-issue: invalid-title-format"
+enable_title_validation = true
+# default_title_pattern = "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9_-]+\\))?!?: .+"
+default_invalid_title_label = "pr-issue: invalid-title-format"
 
 # Require a work-item reference in the pull request description by default.
-enforceWorkItemValidation = true
-# workItemPattern = "(?i)(fixes|closes|resolves|references|relates to)\\s+(#\\d+|GH-\\d+|https://github\\.com/[^/]+/[^/]+/issues/\\d+|[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+#\\d+)"
-labelIfWorkItemMissing = "pr-issue: missing-work-item"
+enable_work_item_validation = true
+# default_work_item_pattern = "(?i)(fixes|closes|resolves|references|relates to)\\s+(#\\d+|GH-\\d+|https://github\\.com/[^/]+/[^/]+/issues/\\d+|[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+#\\d+)"
+default_missing_work_item_label = "pr-issue: missing-work-item"
 
 # PR size checking — disabled by default at app level.
-[policies.prSize]
+[policies.pr_size_check]
 enabled = false
 fail_on_oversized = false
 excluded_file_patterns = ["*.md", "*.txt", "docs/*"]
@@ -31,28 +30,28 @@ label_prefix = "size/"
 add_comment = true
 
 # WIP detection — disabled by default at app level.
-[policies.wip]
+[policies.wip_check]
 enforce_wip_blocking = true
 wip_label = "WIP"
 wip_title_patterns = ["WIP", "wip:", "[wip]", "draft:", "Draft:"]
 wip_description_patterns = []
 
 # PR state lifecycle labels — disabled by default at app level.
-[policies.prState]
+[policies.pr_state_labels]
 enabled = true
 draft_label = "status: draft"
 review_label = "status: in-review"
 approved_label = "status: approved"
 
 # Bypass rules — allow specific GitHub usernames to skip validations.
-[policies.bypassRules.title_convention]
+[policies.bypass_rules.title_convention]
 enabled = false
 users = []
 
-[policies.bypassRules.work_items]
+[policies.bypass_rules.work_items]
 enabled = false
 users = []
 
-[policies.bypassRules.size]
+[policies.bypass_rules.size]
 enabled = false
 users = []


### PR DESCRIPTION
Removes all camelCase serde rename attributes from `ApplicationDefaults` so the
app-level config file uses the same snake_case field names as the per-repository
`merge-warden.toml`.

closes #228

## What Changed

Removed 10 `#[serde(rename = "...")]` attributes from the `ApplicationDefaults`
struct in `crates/core/src/config.rs`. TOML deserialization now uses the Rust
field names directly:

| Old key | New key |
|---|---|
| `enforceTitleValidation` | `enable_title_validation` |
| `titlePattern` | `default_title_pattern` |
| `labelIfTitleInvalid` | `default_invalid_title_label` |
| `enforceWorkItemValidation` | `enable_work_item_validation` |
| `workItemPattern` | `default_work_item_pattern` |
| `labelIfWorkItemMissing` | `default_missing_work_item_label` |
| `bypassRules` | `bypass_rules` |
| `prSize` | `pr_size_check` |
| `wip` | `wip_check` |
| `prState` | `pr_state_labels` |

`samples/app-config.sample.toml` and all user-facing documentation updated to
match. All `#[serde(default)]` attributes preserved — no existing default values
changed.

## Why

The app-level config (`MERGE_WARDEN_CONFIG_FILE`) used camelCase TOML keys while
the per-repository `.github/merge-warden.toml` used snake_case throughout. This
inconsistency was a source of operator confusion and was explicitly called out in
issue #228. With one app config file versus many repo config files, it is the
lower-cost side to break.

## How

Removed only the `rename` argument from each `#[serde(...)]` attribute, leaving
the `default` argument intact. Serde silently ignores unrecognised TOML keys, so
existing deployments will not error on startup — they will fall back to compiled-in
defaults for any key they have not yet renamed. The sample file and all linked
documentation pages were updated in the same commit.

## Testing Evidence

- **Test Coverage:** Fixed two existing JSON serialization assertions that referenced
  old camelCase keys (`enforceTitleValidation`, `bypassRules`). Added two new tests:
  `test_application_defaults_new_field_names_round_trip_toml` (full serialize/
  deserialize cycle asserting snake_case keys are present and camelCase keys absent),
  and `test_application_defaults_camelcase_keys_no_longer_deserialize` (confirms old
  keys are silently ignored and defaults apply). Updated the server config write-file
  test to use the new key name.
- **Test Results:** All 68 core config tests and all 19 server config tests pass. No
  new clippy warnings introduced in changed files (pre-existing warnings in `lib.rs`
  are unrelated to this change).
- **Manual Testing:** Not required — behaviour is fully covered by the round-trip and
  default-fallback tests.

## Reviewer Guidance

- **Breaking change:** Any existing `MERGE_WARDEN_CONFIG_FILE` TOML must be updated
  to use snake_case keys. Old camelCase keys are silently ignored (serde default
  applies), so misconfigured files will not fail at startup — they will simply not
  enforce the policies they intended to set. Operators should be notified to update
  their config files.
- Verify that the `#[serde(default = "...")]` function references on each field are
  still correct after the rename attribute removal.
- Check that the sample TOML in `docs/user/reference/app-config.md` matches
  `samples/app-config.sample.toml` exactly.