### PR TITLE
fix(labels): make size label discovery case-insensitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,7 +2618,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merge-warden-integration-tests"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "merge_warden_cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "merge_warden_core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "merge_warden_developer_platforms"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "merge_warden_server"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -1206,7 +1206,7 @@ impl LabelDetector {
 
     /// Find exact size match: size/XS, size/S, etc.
     fn find_exact_size_match<'a>(&self, labels: &'a [Label], category: &str) -> Option<&'a Label> {
-        let pattern = format!(r"^size/{}$", regex::escape(category));
+        let pattern = format!(r"(?i)^size/{}$", regex::escape(category));
         let regex = Regex::new(&pattern).ok()?;
 
         debug!(
@@ -1237,7 +1237,7 @@ impl LabelDetector {
         labels: &'a [Label],
         category: &str,
     ) -> Option<&'a Label> {
-        let pattern = format!(r"^size[_\-:\s]+{}$", regex::escape(category));
+        let pattern = format!(r"(?i)^size[_\-:\s]+{}$", regex::escape(category));
         let regex = Regex::new(&pattern).ok()?;
 
         debug!(

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -1144,7 +1144,7 @@ impl LabelDetector {
                 category = category,
                 found_label = %label.name,
                 detection_method = "exact_size_match",
-                pattern = format!("^size/{}$", category),
+                pattern = format!("(?i)^size/{}$", category),
                 "Found size label using exact match"
             );
             return Some(label.name.clone());
@@ -1158,7 +1158,7 @@ impl LabelDetector {
                 category = category,
                 found_label = %label.name,
                 detection_method = "size_with_separator",
-                pattern = format!("^size[_\\-:\\s]+{}$", category),
+                pattern = format!("(?i)^size[_\\-:\\s]+{}$", category),
                 "Found size label using separator match"
             );
             return Some(label.name.clone());

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -1109,6 +1109,10 @@ async fn test_label_detector_size_labels_separator_match_lowercase() {
         name: "size:xl".to_string(),
         description: Some("Extra large PR".to_string()),
     });
+    provider.add_repository_label(Label {
+        name: "size:xxl".to_string(),
+        description: Some("Extra extra large PR".to_string()),
+    });
 
     let detector = LabelDetector::new_for_size_labels();
     let discovered = detector
@@ -1121,6 +1125,53 @@ async fn test_label_detector_size_labels_separator_match_lowercase() {
     assert_eq!(discovered.m, Some("size:m".to_string()));
     assert_eq!(discovered.l, Some("size:l".to_string()));
     assert_eq!(discovered.xl, Some("size:xl".to_string()));
+    assert_eq!(discovered.xxl, Some("size:xxl".to_string()));
+}
+
+#[test]
+async fn test_label_detector_size_labels_exact_match_lowercase() {
+    // Regression test: lowercase slash-variant labels like "size/l" must be
+    // discovered correctly. find_exact_size_match received the same (?i) fix as
+    // find_size_with_separator, so this test verifies that path.
+    let provider = SmartMockGitProvider::new();
+
+    provider.add_repository_label(Label {
+        name: "size/xs".to_string(),
+        description: Some("Extra small PR".to_string()),
+    });
+    provider.add_repository_label(Label {
+        name: "size/s".to_string(),
+        description: Some("Small PR".to_string()),
+    });
+    provider.add_repository_label(Label {
+        name: "size/m".to_string(),
+        description: Some("Medium PR".to_string()),
+    });
+    provider.add_repository_label(Label {
+        name: "size/l".to_string(),
+        description: Some("Large PR".to_string()),
+    });
+    provider.add_repository_label(Label {
+        name: "size/xl".to_string(),
+        description: Some("Extra large PR".to_string()),
+    });
+    provider.add_repository_label(Label {
+        name: "size/xxl".to_string(),
+        description: Some("Extra extra large PR".to_string()),
+    });
+
+    let detector = LabelDetector::new_for_size_labels();
+    let discovered = detector
+        .discover_size_labels(&provider, "owner", "repo")
+        .await
+        .unwrap();
+
+    assert_eq!(discovered.xs, Some("size/xs".to_string()));
+    assert_eq!(discovered.s, Some("size/s".to_string()));
+    assert_eq!(discovered.m, Some("size/m".to_string()));
+    assert_eq!(discovered.l, Some("size/l".to_string()));
+    assert_eq!(discovered.xl, Some("size/xl".to_string()));
+    assert_eq!(discovered.xxl, Some("size/xxl".to_string()));
 }
 
 #[test]

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -1082,6 +1082,48 @@ async fn test_label_detector_size_labels_separator_match() {
 }
 
 #[test]
+async fn test_label_detector_size_labels_separator_match_lowercase() {
+    // Regression test: lowercase labels like "size:l" must be discovered correctly.
+    // Previously, find_size_with_separator used a case-sensitive pattern so "size:l"
+    // failed to match category "L", causing a fallback label "size: L" to be created
+    // instead of reusing the existing lowercase label.
+    let provider = SmartMockGitProvider::new();
+
+    provider.add_repository_label(Label {
+        name: "size:xs".to_string(),
+        description: Some("Extra small PR".to_string()),
+    });
+    provider.add_repository_label(Label {
+        name: "size:s".to_string(),
+        description: Some("Small PR".to_string()),
+    });
+    provider.add_repository_label(Label {
+        name: "size:m".to_string(),
+        description: Some("Medium PR".to_string()),
+    });
+    provider.add_repository_label(Label {
+        name: "size:l".to_string(),
+        description: Some("Large PR".to_string()),
+    });
+    provider.add_repository_label(Label {
+        name: "size:xl".to_string(),
+        description: Some("Extra large PR".to_string()),
+    });
+
+    let detector = LabelDetector::new_for_size_labels();
+    let discovered = detector
+        .discover_size_labels(&provider, "owner", "repo")
+        .await
+        .unwrap();
+
+    assert_eq!(discovered.xs, Some("size:xs".to_string()));
+    assert_eq!(discovered.s, Some("size:s".to_string()));
+    assert_eq!(discovered.m, Some("size:m".to_string()));
+    assert_eq!(discovered.l, Some("size:l".to_string()));
+    assert_eq!(discovered.xl, Some("size:xl".to_string()));
+}
+
+#[test]
 async fn test_label_detector_size_labels_standalone_match() {
     let provider = SmartMockGitProvider::new();
 


### PR DESCRIPTION
## Summary

Size label discovery was using case-sensitive regex patterns, so repository labels like `size:l` (lowercase) failed to match category `L`. This caused a new fallback label (`size: L`) to be created instead of reusing the existing label.

## Changes

- Added `(?i)` case-insensitive flag to `find_exact_size_match` and `find_size_with_separator` regex patterns, consistent with `find_description_based` which already had it
- Added regression test `test_label_detector_size_labels_separator_match_lowercase` covering lowercase separator-style labels (`size:xs`, `size:l`, etc.)

## Related

Closes #244