### PR TITLE
chore(config): update merge-warden config and label update script

### DIFF
--- a/.github/merge-warden.toml
+++ b/.github/merge-warden.toml
@@ -33,7 +33,7 @@ label_if_missing = "pr-issue:missing-work-item"
 [policies.pullRequests.prSize]
 enabled = true
 fail_on_oversized = false
-label_prefix = "size/"
+label_prefix = "size:"
 add_comment = true
 
 # Files excluded from the line-change count (glob patterns).
@@ -55,7 +55,7 @@ xl = 700
 # ---------------------------------------------------------------------------
 [policies.pullRequests.wip]
 enforce_wip_blocking = true
-wip_label = "status: wip"
+wip_label = "status:wip"
 wip_title_patterns = ["WIP", "wip:", "[wip]", "draft:", "Draft:"]
 wip_description_patterns = []
 
@@ -116,7 +116,7 @@ build = ["type:ci"]
 revert = ["type:revert"]
 
 [change_type_labels.fallback_label_settings]
-name_format = "type: {change_type}"
+name_format = "type:{change_type}"
 create_if_missing = false
 
 [change_type_labels.fallback_label_settings.color_scheme]

--- a/.github/scripts/update_github_label_colors.ps1
+++ b/.github/scripts/update_github_label_colors.ps1
@@ -26,8 +26,10 @@ $labelUpdates = @(
     @{ Name = "status:needs-triage"; Color = "64befb"; Description = "Needs triage or review" }
     @{ Name = "status:draft"; Color = "64befb"; Description = "Work is in draft mode" }
     @{ Name = "status:in-progress"; Color = "64befb"; Description = "Work in progress" }
+    @{ Name = "status:wip"; Color = "64befb"; Description = "Work in progress (WIP)" }
     @{ Name = "status:needs-review"; Color = "64befb"; Description = "Needs code or design review" }
-    @{ Name = "status:in-review"; Color = "64befb"; Description = "Needs code or design review" }
+    @{ Name = "status:in-review"; Color = "64befb"; Description = "Currently under code or design review" }
+    @{ Name = "status:approved"; Color = "64befb"; Description = "Pull request approved" }
     @{ Name = "status:blocked"; Color = "64befb"; Description = "Blocked by another issue or dependency" }
     @{ Name = "status:completed"; Color = "64befb"; Description = "Work completed" }
 

--- a/.github/scripts/update_github_label_colors.ps1
+++ b/.github/scripts/update_github_label_colors.ps1
@@ -27,6 +27,7 @@ $labelUpdates = @(
     @{ Name = "status:draft"; Color = "64befb"; Description = "Work is in draft mode" }
     @{ Name = "status:in-progress"; Color = "64befb"; Description = "Work in progress" }
     @{ Name = "status:needs-review"; Color = "64befb"; Description = "Needs code or design review" }
+    @{ Name = "status:in-review"; Color = "64befb"; Description = "Needs code or design review" }
     @{ Name = "status:blocked"; Color = "64befb"; Description = "Blocked by another issue or dependency" }
     @{ Name = "status:completed"; Color = "64befb"; Description = "Work completed" }
 


### PR DESCRIPTION
## Summary

Updates to the merge-warden configuration and the GitHub label update script to align label names with what already exists in the repository.

## Changes

- \.github/merge-warden.toml\: updated label name configuration
- \.github/scripts/update_github_label_colors.ps1\: updated label script