### PR TITLE
feat(size): ignore deletions when calculating PR size

### DIFF
--- a/crates/core/src/checks.rs
+++ b/crates/core/src/checks.rs
@@ -1034,6 +1034,7 @@ pub fn check_pr_size(
         pr_files,
         &config.pr_size_check.get_effective_thresholds(),
         &config.pr_size_check.excluded_file_patterns,
+        false,
     );
 
     // Check if we should fail for oversized PRs

--- a/crates/core/src/checks.rs
+++ b/crates/core/src/checks.rs
@@ -1034,7 +1034,7 @@ pub fn check_pr_size(
         pr_files,
         &config.pr_size_check.get_effective_thresholds(),
         &config.pr_size_check.excluded_file_patterns,
-        false,
+        config.pr_size_check.ignore_deletions,
     );
 
     // Check if we should fail for oversized PRs

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -927,6 +927,17 @@ pub struct PrSizeCheckConfig {
     /// Whether to add educational comments for oversized PRs
     #[serde(default = "PrSizeCheckConfig::default_add_comment")]
     pub add_comment: bool,
+
+    /// Whether to ignore deleted lines when calculating PR size.
+    ///
+    /// When `true`, only additions are counted towards the PR size category. This
+    /// prevents large file deletions (e.g., removing a generated file) from
+    /// inflating the size category unfairly.
+    ///
+    /// Defaults to `false` (additions + deletions counted, preserving historical
+    /// behaviour).
+    #[serde(default = "PrSizeCheckConfig::default_ignore_deletions")]
+    pub ignore_deletions: bool,
 }
 
 impl PrSizeCheckConfig {
@@ -948,6 +959,11 @@ impl PrSizeCheckConfig {
     /// Default value for adding educational comments (true)
     fn default_add_comment() -> bool {
         true
+    }
+
+    /// Default value for ignore_deletions (false — count both additions and deletions)
+    fn default_ignore_deletions() -> bool {
+        false
     }
 
     /// Get the effective size thresholds, using defaults if not configured
@@ -980,6 +996,7 @@ impl Default for PrSizeCheckConfig {
             excluded_file_patterns: Vec::new(),
             label_prefix: Self::default_label_prefix(),
             add_comment: Self::default_add_comment(),
+            ignore_deletions: Self::default_ignore_deletions(),
         }
     }
 }

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -762,6 +762,7 @@ fn test_pr_size_check_config_effective_thresholds() {
         excluded_file_patterns: vec![],
         label_prefix: "size/".to_string(),
         add_comment: true,
+        ignore_deletions: false,
     };
     assert_eq!(
         config_with_custom.get_effective_thresholds(),
@@ -782,6 +783,7 @@ fn test_pr_size_check_file_exclusion_patterns() {
         ],
         label_prefix: "size/".to_string(),
         add_comment: true,
+        ignore_deletions: false,
     };
 
     // Test exclusion patterns
@@ -840,6 +842,7 @@ fn test_pr_size_config_serialization() {
         excluded_file_patterns: vec!["*.md".to_string(), "docs/*".to_string()],
         label_prefix: "pr-size/".to_string(),
         add_comment: false,
+        ignore_deletions: false,
     };
 
     // Test that serialization works (this is important for TOML config)
@@ -859,6 +862,42 @@ fn test_pr_size_config_serialization() {
     assert_eq!(
         config.get_effective_thresholds(),
         deserialized.get_effective_thresholds()
+    );
+}
+
+#[test]
+fn test_pr_size_check_config_ignore_deletions_round_trip() {
+    // Verify that ignore_deletions = true survives a TOML serialize → deserialize cycle.
+    let config = PrSizeCheckConfig {
+        enabled: true,
+        thresholds: None,
+        fail_on_oversized: false,
+        excluded_file_patterns: vec![],
+        label_prefix: "size/".to_string(),
+        add_comment: true,
+        ignore_deletions: true,
+    };
+
+    let serialized = toml::to_string(&config).expect("Should serialize");
+
+    // The serialized TOML must contain the snake_case key name.
+    assert!(
+        serialized.contains("ignore_deletions"),
+        "Expected 'ignore_deletions' in serialized TOML, got: {serialized}"
+    );
+
+    let deserialized: PrSizeCheckConfig = toml::from_str(&serialized).expect("Should deserialize");
+
+    assert!(deserialized.ignore_deletions);
+
+    // Also verify that omitting the field from TOML yields the default (false).
+    let minimal_toml = "[pr_size_check]\nenabled = true\n";
+    let minimal: PrSizeCheckConfig =
+        toml::from_str(minimal_toml).expect("Should deserialize minimal TOML");
+
+    assert!(
+        !minimal.ignore_deletions,
+        "ignore_deletions should default to false when absent from TOML"
     );
 }
 
@@ -915,6 +954,7 @@ fn test_validation_config_includes_pr_size() {
                     excluded_file_patterns: vec!["*.md".to_string()],
                     label_prefix: "custom/".to_string(),
                     add_comment: false,
+                    ignore_deletions: false,
                 },
                 ..Default::default()
             },

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -632,7 +632,7 @@ pub async fn manage_wip_labels<P: PullRequestProvider>(
 ///         },
 ///     ];
 ///     let thresholds = SizeThresholds::default();
-///     let size_info = PrSizeInfo::from_files_with_exclusions(&files, &thresholds, &[]);
+///     let size_info = PrSizeInfo::from_files_with_exclusions(&files, &thresholds, &[], false);
 ///
 ///     let label = manage_size_labels(
 ///         provider,
@@ -868,7 +868,7 @@ pub async fn manage_size_labels<P: PullRequestProvider>(
 ///     },
 /// ];
 /// let thresholds = SizeThresholds::default();
-/// let size_info = PrSizeInfo::from_files_with_exclusions(&files, &thresholds, &[]);
+/// let size_info = PrSizeInfo::from_files_with_exclusions(&files, &thresholds, &[], false);
 ///
 /// let comment = generate_oversized_pr_comment(&size_info);
 /// assert!(comment.contains("XXL"));

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -2949,6 +2949,7 @@ async fn test_manage_size_labels_skips_api_calls_when_correct_label_already_appl
         }],
         vec![],
         &SizeThresholds::default(),
+        false,
     );
     assert_eq!(size_info.size_category, PrSizeCategory::S);
 
@@ -2992,6 +2993,7 @@ async fn test_manage_size_labels_removes_stale_and_adds_new_when_category_change
         }],
         vec![],
         &SizeThresholds::default(),
+        false,
     );
     assert_eq!(size_info.size_category, PrSizeCategory::M);
 
@@ -3042,6 +3044,7 @@ async fn test_manage_size_labels_removes_all_stale_and_adds_new_when_multiple_si
         }],
         vec![],
         &SizeThresholds::default(),
+        false,
     );
     assert_eq!(size_info.size_category, PrSizeCategory::M);
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1255,6 +1255,7 @@ Please update the PR body to include a valid work item reference."#;
             pr_files,
             &self.config.pr_size_check.get_effective_thresholds(),
             &self.config.pr_size_check.excluded_file_patterns,
+            false,
         );
 
         // Apply size label
@@ -2194,6 +2195,7 @@ Please update the PR body to include a valid work item reference."#;
                 files,
                 &self.config.pr_size_check.get_effective_thresholds(),
                 &self.config.pr_size_check.excluded_file_patterns,
+                false,
             );
             self.config.pr_size_check.fail_on_oversized && size_info.is_oversized()
         } else {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -475,22 +475,20 @@ impl<P: PullRequestProvider + std::fmt::Debug> MergeWarden<P> {
                     .add_comment(repo_owner, repo_name, pr.number, &comment)
                     .await;
 
-                if result.is_ok() {
-                    info!(
+                match result {
+                    Ok(_) => info!(
                         repository_owner = repo_owner,
                         repository = repo_name,
                         pull_request = pr.number,
                         "Added WIP blocking comment to pull request"
-                    );
-                } else {
-                    let e = result.unwrap_err();
-                    warn!(
+                    ),
+                    Err(e) => warn!(
                         repository_owner = repo_owner,
                         repository = repo_name,
                         pull_request = pr.number,
                         error = e.to_string(),
                         "Failed to add WIP blocking comment to pull request"
-                    );
+                    ),
                 }
             }
 
@@ -510,22 +508,20 @@ impl<P: PullRequestProvider + std::fmt::Debug> MergeWarden<P> {
                         .delete_comment(repo_owner, repo_name, comment.id)
                         .await;
 
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             "Removed WIP blocking comment from pull request"
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "Failed to remove WIP blocking comment from pull request"
-                        );
+                        ),
                     }
                 }
             }
@@ -621,22 +617,20 @@ impl<P: PullRequestProvider + std::fmt::Debug> MergeWarden<P> {
                         .add_labels(repo_owner, repo_name, pr.number, &[title_label.to_string()])
                         .await;
 
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             "The pull request title is invalid. Added a label to indicate the issue."
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "The pull request title is invalid. Failed to add a label to indicate the issue."
-                        );
+                        ),
                     }
                 }
             }
@@ -728,22 +722,20 @@ Please update the PR title to match the conventional commit message guidelines."
                         .add_comment(repo_owner, repo_name, pr.number, &comment)
                         .await;
 
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             "The pull request title is invalid. Added a comment to indicate the issue."
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "The pull request title is invalid. Failed to add a comment to indicate the issue."
-                        );
+                        ),
                     }
                 }
             }
@@ -777,22 +769,20 @@ Please update the PR title to match the conventional commit message guidelines."
                         .remove_label(repo_owner, repo_name, pr.number, title_label)
                         .await;
 
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             "The pull request title is valid. Removed a label that was indicating the issue."
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "The pull request title is valid. Failed to remove a label that was indicating the issue."
-                        );
+                        ),
                     }
                 }
             }
@@ -813,22 +803,20 @@ Please update the PR title to match the conventional commit message guidelines."
                         .delete_comment(repo_owner, repo_name, comment.id)
                         .await;
 
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             "Removed existing title validation comment."
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "Failed to remove existing title validation comment."
-                        );
+                        ),
                     }
                 }
             }
@@ -866,23 +854,21 @@ Please update the PR title to match the conventional commit message guidelines."
                         .add_comment(repo_owner, repo_name, pr.number, &comment)
                         .await;
 
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             user = bypass_info.user,
                             "Added bypass notification comment for title validation."
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "Failed to add bypass notification comment."
-                        );
+                        ),
                     }
 
                     return bypass_comment_text;
@@ -979,22 +965,20 @@ Please update the PR title to match the conventional commit message guidelines."
                             &[work_item_label.to_string()],
                         )
                         .await;
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             "The pull request does not have a work item reference. Added a label to indicate the issue."
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "The pull request does not have a work item reference. Failed to add a label to indicate the issue."
-                        );
+                        ),
                     }
                 }
             }
@@ -1064,22 +1048,20 @@ Please update the PR body to include a valid work item reference."#;
                         .add_comment(repo_owner, repo_name, pr.number, &comment)
                         .await;
 
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             "The pull request does not have a work item reference. Added a comment to indicate the issue."
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "The pull request does not have a work item reference. Failed to add a comment to indicate the issue."
-                        );
+                        ),
                     }
                 }
             }
@@ -1114,22 +1096,20 @@ Please update the PR body to include a valid work item reference."#;
                         .remove_label(repo_owner, repo_name, pr.number, work_item_label)
                         .await;
 
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             "The pull request has a work item reference. Removed a label that was indicating the issue."
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "The pull request has a work item reference. Failed to remove a label that was indicating the issue."
-                        );
+                        ),
                     }
                 }
             }
@@ -1148,22 +1128,20 @@ Please update the PR body to include a valid work item reference."#;
                         .delete_comment(repo_owner, repo_name, comment.id)
                         .await;
 
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             "Removed existing work item validation comment."
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "Failed to remove existing work item validation comment."
-                        );
+                        ),
                     }
                 }
             }
@@ -1197,23 +1175,21 @@ Please update the PR body to include a valid work item reference."#;
                         .add_comment(repo_owner, repo_name, pr.number, &comment)
                         .await;
 
-                    if result.is_ok() {
-                        info!(
+                    match result {
+                        Ok(_) => info!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             user = bypass_info.user,
                             "Added bypass notification comment for work item validation."
-                        );
-                    } else {
-                        let e = result.unwrap_err();
-                        warn!(
+                        ),
+                        Err(e) => warn!(
                             repository_owner = repo_owner,
                             repository = repo_name,
                             pull_request = pr.number,
                             error = e.to_string(),
                             "Failed to add bypass notification comment."
-                        );
+                        ),
                     }
 
                     return bypass_comment_text;
@@ -1255,7 +1231,7 @@ Please update the PR body to include a valid work item reference."#;
             pr_files,
             &self.config.pr_size_check.get_effective_thresholds(),
             &self.config.pr_size_check.excluded_file_patterns,
-            false,
+            self.config.pr_size_check.ignore_deletions,
         );
 
         // Apply size label
@@ -2195,7 +2171,7 @@ Please update the PR body to include a valid work item reference."#;
                 files,
                 &self.config.pr_size_check.get_effective_thresholds(),
                 &self.config.pr_size_check.excluded_file_patterns,
-                false,
+                self.config.pr_size_check.ignore_deletions,
             );
             self.config.pr_size_check.fail_on_oversized && size_info.is_oversized()
         } else {

--- a/crates/core/src/size.rs
+++ b/crates/core/src/size.rs
@@ -318,6 +318,7 @@ impl PrSizeInfo {
     /// * `included_files` - Files to include in size calculation
     /// * `excluded_files` - Files excluded from size calculation
     /// * `thresholds` - Size category thresholds to use
+    /// * `ignore_deletions` - When `true`, count only additions; when `false`, count additions + deletions
     ///
     /// # Examples
     ///
@@ -338,7 +339,8 @@ impl PrSizeInfo {
     /// let size_info = PrSizeInfo::new(
     ///     files,
     ///     vec![],
-    ///     &SizeThresholds::default()
+    ///     &SizeThresholds::default(),
+    ///     false,
     /// );
     ///
     /// assert_eq!(size_info.total_lines_changed, 15);
@@ -347,6 +349,7 @@ impl PrSizeInfo {
         included_files: Vec<PullRequestFile>,
         excluded_files: Vec<PullRequestFile>,
         thresholds: &SizeThresholds,
+        _ignore_deletions: bool,
     ) -> Self {
         let total_lines_changed: u32 = included_files.iter().map(|f| f.changes).sum();
         let size_category =
@@ -370,6 +373,7 @@ impl PrSizeInfo {
     /// * `all_files` - All files changed in the pull request
     /// * `thresholds` - Size category thresholds to use
     /// * `exclusion_patterns` - Patterns for files to exclude from size calculation
+    /// * `ignore_deletions` - When `true`, count only additions; when `false`, count additions + deletions
     ///
     /// # Examples
     ///
@@ -398,7 +402,8 @@ impl PrSizeInfo {
     /// let size_info = PrSizeInfo::from_files_with_exclusions(
     ///     &files,
     ///     &SizeThresholds::default(),
-    ///     &exclusion_patterns
+    ///     &exclusion_patterns,
+    ///     false,
     /// );
     ///
     /// assert_eq!(size_info.total_lines_changed, 15); // Only src/lib.rs counted
@@ -409,10 +414,11 @@ impl PrSizeInfo {
         all_files: &[merge_warden_developer_platforms::models::PullRequestFile],
         thresholds: &SizeThresholds,
         exclusion_patterns: &[String],
+        ignore_deletions: bool,
     ) -> Self {
         let (included_files, excluded_files) =
             filter_files_by_patterns(all_files, exclusion_patterns);
-        Self::new(included_files, excluded_files, thresholds)
+        Self::new(included_files, excluded_files, thresholds, ignore_deletions)
     }
 
     /// Check if this PR is considered oversized based on its category.
@@ -463,7 +469,8 @@ impl PrSizeInfo {
     /// let size_info = PrSizeInfo::new(
     ///     files,
     ///     vec![],
-    ///     &merge_warden_core::size::SizeThresholds::default()
+    ///     &merge_warden_core::size::SizeThresholds::default(),
+    ///     false,
     /// );
     ///
     /// assert_eq!(size_info.included_file_count(), 2);
@@ -493,7 +500,8 @@ impl PrSizeInfo {
     /// let size_info = PrSizeInfo::new(
     ///     vec![],
     ///     excluded,
-    ///     &merge_warden_core::size::SizeThresholds::default()
+    ///     &merge_warden_core::size::SizeThresholds::default(),
+    ///     false,
     /// );
     ///
     /// assert_eq!(size_info.excluded_file_count(), 1);

--- a/crates/core/src/size.rs
+++ b/crates/core/src/size.rs
@@ -349,9 +349,13 @@ impl PrSizeInfo {
         included_files: Vec<PullRequestFile>,
         excluded_files: Vec<PullRequestFile>,
         thresholds: &SizeThresholds,
-        _ignore_deletions: bool,
+        ignore_deletions: bool,
     ) -> Self {
-        let total_lines_changed: u32 = included_files.iter().map(|f| f.changes).sum();
+        let total_lines_changed: u32 = if ignore_deletions {
+            included_files.iter().map(|f| f.additions).sum()
+        } else {
+            included_files.iter().map(|f| f.changes).sum()
+        };
         let size_category =
             PrSizeCategory::from_line_count_with_thresholds(total_lines_changed, thresholds);
 

--- a/crates/core/src/size.rs
+++ b/crates/core/src/size.rs
@@ -294,7 +294,12 @@ impl SizeThresholds {
 /// ```
 #[derive(Debug, Clone)]
 pub struct PrSizeInfo {
-    /// Total lines changed (additions + deletions) excluding filtered files
+    /// Total lines counted for size categorisation, excluding filtered files.
+    ///
+    /// When `ignore_deletions` is `false` (the default), this is the sum of
+    /// `additions + deletions` (`f.changes`) across all included files.
+    /// When `ignore_deletions` is `true`, this holds additions only (`f.additions`);
+    /// deleted lines and wholly-removed files contribute 0.
     pub total_lines_changed: u32,
 
     /// List of files included in the size calculation

--- a/crates/core/src/size_tests.rs
+++ b/crates/core/src/size_tests.rs
@@ -175,7 +175,7 @@ fn test_size_thresholds_custom() {
 
 #[test]
 fn test_pr_size_info_new_empty() {
-    let size_info = PrSizeInfo::new(vec![], vec![], &SizeThresholds::default());
+    let size_info = PrSizeInfo::new(vec![], vec![], &SizeThresholds::default(), false);
 
     assert_eq!(size_info.total_lines_changed, 0);
     assert_eq!(size_info.size_category, PrSizeCategory::XS);
@@ -194,7 +194,7 @@ fn test_pr_size_info_new_single_file() {
         status: "modified".to_string(),
     };
 
-    let size_info = PrSizeInfo::new(vec![file], vec![], &SizeThresholds::default());
+    let size_info = PrSizeInfo::new(vec![file], vec![], &SizeThresholds::default(), false);
 
     assert_eq!(size_info.total_lines_changed, 20);
     assert_eq!(size_info.size_category, PrSizeCategory::S);
@@ -229,7 +229,7 @@ fn test_pr_size_info_new_multiple_files() {
         },
     ];
 
-    let size_info = PrSizeInfo::new(files, vec![], &SizeThresholds::default());
+    let size_info = PrSizeInfo::new(files, vec![], &SizeThresholds::default(), false);
 
     assert_eq!(size_info.total_lines_changed, 85); // 20 + 40 + 25
     assert_eq!(size_info.size_category, PrSizeCategory::M);
@@ -265,7 +265,12 @@ fn test_pr_size_info_new_with_excluded_files() {
         },
     ];
 
-    let size_info = PrSizeInfo::new(included_files, excluded_files, &SizeThresholds::default());
+    let size_info = PrSizeInfo::new(
+        included_files,
+        excluded_files,
+        &SizeThresholds::default(),
+        false,
+    );
 
     // Should only count included files
     assert_eq!(size_info.total_lines_changed, 15);
@@ -285,7 +290,7 @@ fn test_pr_size_info_oversized() {
         status: "modified".to_string(),
     }];
 
-    let size_info = PrSizeInfo::new(files, vec![], &SizeThresholds::default());
+    let size_info = PrSizeInfo::new(files, vec![], &SizeThresholds::default(), false);
 
     assert_eq!(size_info.total_lines_changed, 600);
     assert_eq!(size_info.size_category, PrSizeCategory::XXL);
@@ -311,7 +316,7 @@ fn test_pr_size_info_with_custom_thresholds() {
         status: "modified".to_string(),
     }];
 
-    let size_info = PrSizeInfo::new(files, vec![], &custom_thresholds);
+    let size_info = PrSizeInfo::new(files, vec![], &custom_thresholds, false);
 
     assert_eq!(size_info.total_lines_changed, 30);
     assert_eq!(size_info.size_category, PrSizeCategory::M); // Exactly at the M threshold
@@ -427,7 +432,7 @@ fn test_pr_size_info_zero_changes_file() {
         },
     ];
 
-    let size_info = PrSizeInfo::new(files, vec![], &SizeThresholds::default());
+    let size_info = PrSizeInfo::new(files, vec![], &SizeThresholds::default(), false);
 
     assert_eq!(size_info.total_lines_changed, 7); // Only the modified file counts
     assert_eq!(size_info.size_category, PrSizeCategory::XS);
@@ -458,6 +463,7 @@ fn test_pr_size_info_from_files_with_exclusions() {
         &files,
         &SizeThresholds::default(),
         &exclusion_patterns,
+        false,
     );
 
     // Only the main.rs file should be included in size calculation
@@ -487,7 +493,8 @@ fn test_pr_size_info_no_exclusions() {
         },
     ];
 
-    let size_info = PrSizeInfo::from_files_with_exclusions(&files, &SizeThresholds::default(), &[]);
+    let size_info =
+        PrSizeInfo::from_files_with_exclusions(&files, &SizeThresholds::default(), &[], false);
 
     // All files should be included
     assert_eq!(size_info.total_lines_changed, 45); // 15 + 30
@@ -505,9 +512,139 @@ fn test_size_category_determination() {
         status: "modified".to_string(),
     }];
 
-    let size_info = PrSizeInfo::from_files_with_exclusions(&files, &SizeThresholds::default(), &[]);
+    let size_info =
+        PrSizeInfo::from_files_with_exclusions(&files, &SizeThresholds::default(), &[], false);
 
     // 800 lines should be XXL with default thresholds
     assert!(size_info.is_oversized());
     assert_eq!(size_info.size_category, PrSizeCategory::XXL);
+}
+
+// ── ignore_deletions tests ────────────────────────────────────────────────────
+
+#[test]
+fn test_pr_size_info_ignore_deletions_false_uses_changes() {
+    // When ignore_deletions is false (default), f.changes (additions + deletions) is used.
+    // This test documents the current behaviour and ensures it is not broken.
+    let file = PullRequestFile {
+        filename: "src/main.rs".to_string(),
+        additions: 10,
+        deletions: 500,
+        changes: 510,
+        status: "modified".to_string(),
+    };
+
+    let size_info = PrSizeInfo::new(vec![file], vec![], &SizeThresholds::default(), false);
+
+    assert_eq!(size_info.total_lines_changed, 510);
+}
+
+#[test]
+fn test_pr_size_info_ignore_deletions_true_uses_additions_only() {
+    // When ignore_deletions is true, only f.additions is counted.
+    // A large deletion must not inflate the size category.
+    let file = PullRequestFile {
+        filename: "src/main.rs".to_string(),
+        additions: 10,
+        deletions: 500,
+        changes: 510,
+        status: "modified".to_string(),
+    };
+
+    let size_info = PrSizeInfo::new(vec![file], vec![], &SizeThresholds::default(), true);
+
+    assert_eq!(size_info.total_lines_changed, 10);
+    assert_eq!(size_info.size_category, PrSizeCategory::XS);
+}
+
+#[test]
+fn test_pr_size_info_wholly_deleted_file_contributes_zero_when_ignore_deletions() {
+    // A file with status "removed" has additions=0 and deletions > 0.
+    // When ignore_deletions is true, it contributes 0 lines.
+    let deleted_file = PullRequestFile {
+        filename: "src/old_module.rs".to_string(),
+        additions: 0,
+        deletions: 2000,
+        changes: 2000,
+        status: "removed".to_string(),
+    };
+    let new_file = PullRequestFile {
+        filename: "src/new_module.rs".to_string(),
+        additions: 25,
+        deletions: 0,
+        changes: 25,
+        status: "added".to_string(),
+    };
+
+    let size_info = PrSizeInfo::new(
+        vec![deleted_file, new_file],
+        vec![],
+        &SizeThresholds::default(),
+        true,
+    );
+
+    // Only the 25 additions from new_module.rs count; the removed file contributes 0.
+    assert_eq!(size_info.total_lines_changed, 25);
+    assert_eq!(size_info.size_category, PrSizeCategory::S);
+}
+
+#[test]
+fn test_pr_size_info_mixed_pr_ignore_deletions_true() {
+    // Multiple files — only additions are summed when ignore_deletions is true.
+    let files = vec![
+        PullRequestFile {
+            filename: "src/feature.rs".to_string(),
+            additions: 50,
+            deletions: 20,
+            changes: 70,
+            status: "modified".to_string(),
+        },
+        PullRequestFile {
+            filename: "src/cleanup.rs".to_string(),
+            additions: 5,
+            deletions: 300,
+            changes: 305,
+            status: "modified".to_string(),
+        },
+    ];
+
+    let size_info_with = PrSizeInfo::new(files.clone(), vec![], &SizeThresholds::default(), true);
+    let size_info_without = PrSizeInfo::new(files, vec![], &SizeThresholds::default(), false);
+
+    assert_eq!(size_info_with.total_lines_changed, 55); // 50 + 5 additions only
+    assert_eq!(size_info_without.total_lines_changed, 375); // 70 + 305 changes
+}
+
+#[test]
+fn test_pr_size_info_from_files_with_exclusions_ignore_deletions_true() {
+    // The ignore_deletions flag threads through from_files_with_exclusions to new().
+    let files = vec![
+        PullRequestFile {
+            filename: "src/main.rs".to_string(),
+            additions: 15,
+            deletions: 200,
+            changes: 215,
+            status: "modified".to_string(),
+        },
+        PullRequestFile {
+            filename: "package-lock.json".to_string(),
+            additions: 1000,
+            deletions: 500,
+            changes: 1500,
+            status: "modified".to_string(),
+        },
+    ];
+    let exclusion_patterns = vec!["package-lock.json".to_string()];
+
+    let size_info = PrSizeInfo::from_files_with_exclusions(
+        &files,
+        &SizeThresholds::default(),
+        &exclusion_patterns,
+        true,
+    );
+
+    // package-lock.json is excluded; only main.rs additions (15) count.
+    assert_eq!(size_info.total_lines_changed, 15);
+    assert_eq!(size_info.included_files.len(), 1);
+    assert_eq!(size_info.excluded_files.len(), 1);
 }

--- a/docs/user/reference/app-config.md
+++ b/docs/user/reference/app-config.md
@@ -43,6 +43,7 @@ Top-level policy defaults.
 | `enabled` | bool | `false` | Enable PR size labeling for all repositories. |
 | `fail_on_oversized` | bool | `false` | Fail the check for XXL PRs. |
 | `excluded_file_patterns` | array of strings | `[]` | Glob patterns excluded from line counts. |
+| `ignore_deletions` | bool | `false` | When `true`, only additions are counted; deleted lines do not contribute to the PR size. |
 | `label_prefix` | string | `"size/"` | Label prefix (e.g. `size/XS`). |
 | `add_comment` | bool | `true` | Post a comment on oversized PRs. |
 

--- a/docs/user/reference/per-repo-config.md
+++ b/docs/user/reference/per-repo-config.md
@@ -63,6 +63,7 @@ Controls automatic PR size labeling.
 | `enabled` | bool | `false` | When `true`, size labels are applied on every PR event. |
 | `fail_on_oversized` | bool | `false` | When `true`, the check fails for XXL PRs (above the `xl` threshold). |
 | `excluded_file_patterns` | array of strings | `[]` | Glob patterns for files to exclude from the line count. |
+| `ignore_deletions` | bool | `false` | When `true`, only additions are counted; deleted lines do not contribute to the PR size. |
 | `label_prefix` | string | `"size/"` | Prefix prepended to size tier names to form the label (e.g. `size/XS`). |
 | `add_comment` | bool | `true` | When `true`, an educational comment is posted on XXL PRs. |
 

--- a/samples/app-config.sample.toml
+++ b/samples/app-config.sample.toml
@@ -26,6 +26,8 @@ default_missing_work_item_label = "pr-issue: missing-work-item"
 enabled = false
 fail_on_oversized = false
 excluded_file_patterns = ["*.md", "*.txt", "docs/*"]
+# When true, only additions are counted; deleted lines do not inflate the PR size.
+ignore_deletions = false
 label_prefix = "size/"
 add_comment = true
 

--- a/samples/merge-warden.sample.toml
+++ b/samples/merge-warden.sample.toml
@@ -35,6 +35,9 @@ fail_on_oversized = false
 # File patterns to exclude from size calculations (supports glob patterns)
 excluded_file_patterns = ["*.md", "*.txt", "docs/*"]
 
+# When true, only additions are counted; deleted lines do not inflate the PR size.
+ignore_deletions = false
+
 # Prefix for size labels (will create labels like "size/XS", "size/S", etc.)
 label_prefix = "size/"
 


### PR DESCRIPTION
## Summary

Closes #240

Adds an `ignore_deletions` option to the PR size configuration. When enabled, only line additions are counted toward the PR size category - deleted lines no longer inflate the size.

## Changes

- **`crates/core/src/config.rs`** - Added `ignore_deletions: bool` field to `PrSizeCheckConfig` (default `false`, backward-compatible)
- **`crates/core/src/size.rs`** - `PrSizeInfo::new` and `from_files_with_exclusions` accept and apply the flag; sums `f.additions` when `true`, `f.changes` otherwise
- **`crates/core/src/checks.rs`** and **`crates/core/src/lib.rs`** - All call sites updated to pass the flag from config
- **`crates/core/src/size_tests.rs`** - New tests: additions-only mode, wholly-deleted files (contribute 0), mixed PRs, default unchanged
- **`crates/core/src/config_tests.rs`** - TOML round-trip test for the new field
- **`docs/user/reference/`** and **`samples/`** - Field documented and included in sample configs

Also fixed 12 pre-existing `clippy::unnecessary_unwrap` errors in `lib.rs` (if/else + unwrap_err to match) that would have failed CI.

## Behaviour

| `ignore_deletions` | File: additions=10 deletions=500 | Wholly-deleted file |
|---|---|---|
| `false` (default) | 510 lines (unchanged) | 2000 lines |
| `true` | 10 lines | 0 lines |

## Test results

- 383 unit tests pass
- 58 doc tests pass
- cargo clippy -p merge_warden_core -- -D warnings clean