### PR TITLE
feat(core): add negation-aware keyword labels, comment suppression, and explanation comments

### DIFF
--- a/crates/cli/src/commands/check_pr.rs
+++ b/crates/cli/src/commands/check_pr.rs
@@ -217,6 +217,7 @@ impl WebhookHandler for MergeWardenWebhookHandler {
                     wip_check: self.config.policies.wip_check.clone(),
                     pr_state_labels: self.config.policies.pr_state_labels.clone(),
                     issue_propagation: Default::default(),
+                    bot_mention: self.config.policies.bot_mention.clone(),
                 }
             }
         };

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -37,6 +37,13 @@ pub const SIZE_COMMENT_MARKER: &str = "<!-- PR_SIZE_CHECK -->";
 /// HTML comment marker for WIP (Work In Progress) validation comments
 pub const WIP_COMMENT_MARKER: &str = "<!-- PR_WIP_CHECK -->";
 
+/// HTML comment marker prefix for keyword-triggered label explanation comments.
+///
+/// The full per-label marker appends the resolved label name and a closing delimiter,
+/// e.g. `<!-- MERGE_WARDEN_KEYWORD_LABEL:breaking-change -->`.  Searching for this
+/// prefix is sufficient to locate any keyword-label explanation comment.
+pub const KEYWORD_LABEL_COMMENT_MARKER: &str = "<!-- MERGE_WARDEN_KEYWORD_LABEL:";
+
 /// Pre-compiled regex for conventional commit format validation
 ///
 /// This regex enforces the Conventional Commits specification (https://conventionalcommits.org/)
@@ -284,6 +291,15 @@ pub struct ApplicationDefaults {
     /// Application-level defaults for state-based PR lifecycle labels
     #[serde(default)]
     pub pr_state_labels: PrStateLabelsConfig,
+
+    /// Bot mention prefix used for comment-based label suppression.
+    ///
+    /// PR participants post a comment line of the form `<bot_mention> suppress: <label-name>`
+    /// to prevent merge-warden from (re-)applying a keyword-triggered label.  Defaults to
+    /// `"@merge-warden"`.  Operators running a custom GitHub App installation should set this
+    /// to their app's mention handle (e.g. `"@acme-merge-warden[bot]"`).
+    #[serde(default = "ApplicationDefaults::default_bot_mention")]
+    pub bot_mention: String,
 }
 
 impl ApplicationDefaults {
@@ -316,6 +332,11 @@ impl ApplicationDefaults {
     fn default_work_item_required() -> bool {
         false
     }
+
+    /// Default bot mention prefix for comment-based label suppression.
+    fn default_bot_mention() -> String {
+        "@merge-warden".to_string()
+    }
 }
 
 impl Default for ApplicationDefaults {
@@ -332,6 +353,7 @@ impl Default for ApplicationDefaults {
             change_type_labels: ChangeTypeLabelConfig::default(),
             wip_check: WipCheckConfig::default(),
             pr_state_labels: PrStateLabelsConfig::default(),
+            bot_mention: ApplicationDefaults::default_bot_mention(),
         }
     }
 }
@@ -616,6 +638,9 @@ pub struct CurrentPullRequestValidationConfiguration {
 
     /// Configuration for issue metadata propagation.
     pub issue_propagation: IssuePropagationConfig,
+
+    /// Bot mention prefix used to parse label suppression commands from PR comments.
+    pub bot_mention: String,
 }
 
 impl CurrentPullRequestValidationConfiguration {
@@ -652,6 +677,7 @@ impl CurrentPullRequestValidationConfiguration {
             pr_state_labels: PrStateLabelsConfig::default(),
             bypass_rules: bypass_rules.unwrap_or_default(),
             issue_propagation: IssuePropagationConfig::default(),
+            bot_mention: "@merge-warden".to_string(),
         }
     }
 }
@@ -671,6 +697,7 @@ impl Default for CurrentPullRequestValidationConfiguration {
             pr_state_labels: PrStateLabelsConfig::default(),
             bypass_rules: BypassRules::default(),
             issue_propagation: IssuePropagationConfig::default(),
+            bot_mention: "@merge-warden".to_string(),
         }
     }
 }
@@ -804,6 +831,13 @@ pub struct RepositoryProvidedConfig {
     /// Repository-specific change type label configuration overrides
     #[serde(default)]
     pub change_type_labels: Option<ChangeTypeLabelConfig>,
+
+    /// Bot mention prefix resolved from application defaults; not read from TOML.
+    ///
+    /// Set by [`load_merge_warden_config`] after deserialisation, from
+    /// [`ApplicationDefaults::bot_mention`].
+    #[serde(skip)]
+    pub bot_mention: String,
 }
 
 /// Convert a RepositoryConfig (TOML) to a ValidationConfig (runtime enforcement)
@@ -852,6 +886,7 @@ impl RepositoryProvidedConfig {
             pr_state_labels,
             bypass_rules: bypass_rules.clone(),
             issue_propagation: pr_policies.issue_propagation.clone(),
+            bot_mention: self.bot_mention.clone(),
         }
     }
 }
@@ -862,6 +897,7 @@ impl Default for RepositoryProvidedConfig {
             schema_version: 1,
             policies: PoliciesConfig::default(),
             change_type_labels: None,
+            bot_mention: "@merge-warden".to_string(),
         }
     }
 }
@@ -1605,6 +1641,11 @@ pub async fn load_merge_warden_config(
         pr_size_label_prefix = config.policies.pull_requests.size_policies.label_prefix,
         "Configuration loaded"
     );
+
+    // Thread the bot_mention from application defaults into the resolved config
+    // so that CurrentPullRequestValidationConfiguration carries it without requiring
+    // callers to pass it separately.
+    config.bot_mention = app_defaults.bot_mention.clone();
 
     Ok(config)
 }

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -183,6 +183,7 @@ fn test_custom_regex_patterns_are_used() {
             },
         },
         change_type_labels: None,
+        ..Default::default()
     };
     let validation = config.to_validation_config(&BypassRules::default());
     let custom_title = "CUSTOM: test title";
@@ -439,6 +440,7 @@ fn test_merge_warden_config_to_validation_config_conventional_commits_and_work_i
             },
         },
         change_type_labels: None,
+        ..Default::default()
     };
     let validation = config.to_validation_config(&BypassRules::default());
     assert!(validation.enforce_title_convention);
@@ -474,6 +476,7 @@ fn test_merge_warden_config_to_validation_config_non_conventional_commits() {
             },
         },
         change_type_labels: None,
+        ..Default::default()
     };
     let validation = config.to_validation_config(&BypassRules::default());
     assert!(!validation.enforce_title_convention);
@@ -722,6 +725,7 @@ fn test_application_defaults_bypass_rules_serialization() {
         change_type_labels: ChangeTypeLabelConfig::default(),
         wip_check: WipCheckConfig::default(),
         pr_state_labels: crate::config::PrStateLabelsConfig::default(),
+        bot_mention: "@merge-warden".to_string(),
     };
 
     let serialized =
@@ -960,6 +964,7 @@ fn test_validation_config_includes_pr_size() {
             },
         },
         change_type_labels: None,
+        ..Default::default()
     };
 
     let validation = repo_config.to_validation_config(&BypassRules::default());
@@ -1086,6 +1091,7 @@ fn test_to_validation_config_preserves_wip_policies() {
             },
         },
         change_type_labels: None,
+        ..Default::default()
     };
 
     let validation = repo_config.to_validation_config(&BypassRules::default());

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -394,6 +394,18 @@ pub async fn set_pull_request_labels_with_config<P: PullRequestProvider>(
             additional_labels.push(label_name.clone());
             labels.push(label_name.clone());
         } else if is_suppressed {
+            let commenter = suppressed
+                .get(label_name.as_str())
+                .map(|s| s.as_str())
+                .unwrap_or("unknown");
+            warn!(
+                repository_owner = owner,
+                repository = repo,
+                pr_number = pr.number,
+                label = %label_name,
+                suppressed_by = commenter,
+                "Keyword label suppressed by user comment; skipping label application"
+            );
             // Remove the label from the PR if it is currently applied.
             if applied_labels.iter().any(|l| &l.name == label_name) {
                 if let Err(e) = provider

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -575,7 +575,7 @@ fn is_keyword_negated(text: &str, keyword_span: std::ops::Range<usize>) -> bool 
 
     // Restrict look-back to current clause (stop at sentence / clause boundaries).
     let clause_start = before
-        .rfind(|c| matches!(c, '.' | '!' | '?' | ';' | '\n'))
+        .rfind(['.', '!', '?', ';', '\n'])
         .map(|i| i + 1)
         .unwrap_or(0);
     let clause_before = &before[clause_start..];
@@ -647,14 +647,14 @@ fn parse_suppressed_labels(comments: &[Comment], bot_mention: &str) -> HashMap<S
 /// * `bot_mention` - The bot mention prefix (e.g. `"@merge-warden"`).
 fn build_keyword_label_comment(label_name: &str, bot_mention: &str) -> String {
     format!(
-        "{label_marker} -->\n\
+        "{marker}{label} -->\n\
          **Merge Warden** automatically applied the `{label}` label because keywords \
          in this pull request triggered keyword detection.\n\n\
          To suppress this label, add the following comment:\n\
          ```\n\
          {bot} suppress: {label}\n\
          ```",
-        label_marker = format!("{}{}", KEYWORD_LABEL_COMMENT_MARKER, label_name),
+        marker = KEYWORD_LABEL_COMMENT_MARKER,
         label = label_name,
         bot = bot_mention,
     )

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -11,14 +11,44 @@
 
 use crate::config::{
     ChangeTypeLabelConfig, CurrentPullRequestValidationConfiguration, KeywordLabelsConfig,
-    PrStateLabelsConfig, CONVENTIONAL_COMMIT_REGEX,
+    PrStateLabelsConfig, CONVENTIONAL_COMMIT_REGEX, KEYWORD_LABEL_COMMENT_MARKER,
 };
 use crate::errors::MergeWardenError;
 use crate::size::{PrSizeCategory, PrSizeInfo};
-use merge_warden_developer_platforms::models::{Label, PullRequest};
+use lazy_static::lazy_static;
+use merge_warden_developer_platforms::models::{Comment, Label, PullRequest};
 use merge_warden_developer_platforms::PullRequestProvider;
 use regex::Regex;
+use std::collections::HashMap;
 use tracing::{debug, info, warn};
+
+lazy_static! {
+    /// Word-boundary regex for detecting "breaking change" / "breaking-change" keywords.
+    static ref BREAKING_CHANGE_KEYWORD_RE: Regex =
+        Regex::new(r"(?i)\bbreaking[\s\-]+change\b").unwrap();
+
+    /// Word-boundary regex for detecting "security" or "vulnerability" keywords.
+    static ref SECURITY_KEYWORD_RE: Regex =
+        Regex::new(r"(?i)\b(security|vulnerability)\b").unwrap();
+
+    /// Word-boundary regex for detecting "hotfix" keyword.
+    static ref HOTFIX_KEYWORD_RE: Regex =
+        Regex::new(r"(?i)\bhotfix\b").unwrap();
+
+    /// Word-boundary regex for detecting "tech debt" / "technical debt" keywords.
+    static ref TECH_DEBT_KEYWORD_RE: Regex =
+        Regex::new(r"(?i)\btech(?:nical)?[\s\-]+debt\b").unwrap();
+}
+
+/// Single-word negation tokens that, when found in the 5-word window immediately
+/// before a keyword match, indicate the keyword phrase is negated.
+const NEGATION_SINGLE_WORDS: &[&str] = &[
+    "no", "not", "never", "without",
+    // Contractions (with and without apostrophe, since punctuation stripping may vary)
+    "don't", "dont", "doesn't", "doesnt",
+    "isn't", "isnt", "aren't", "arent",
+    "won't", "wont",
+];
 
 /// Common WIP label names used for discovery and cleanup.
 ///
@@ -367,6 +397,62 @@ fn add_hardcoded_type_label(labels: &mut Vec<String>, pr_type: &str) {
         "revert" => labels.push("revert".to_string()),
         _ => {}
     }
+}
+
+/// Determines whether a keyword match within `text` is negated by a preceding negation word.
+///
+/// Uses clause-boundary detection (`.`, `!`, `?`, `;`, `\n`) to scope the look-back,
+/// then inspects the 5-word window immediately before `keyword_span` for any word
+/// from [`NEGATION_SINGLE_WORDS`].
+///
+/// # Arguments
+///
+/// * `text` - The full text (lowercased) being searched.
+/// * `keyword_span` - The byte-range of the keyword match within `text`.
+///
+/// # Returns
+///
+/// `true` when a negation word appears within the 5-word window before the keyword
+/// and within the same clause; `false` otherwise.
+fn is_keyword_negated(text: &str, keyword_span: std::ops::Range<usize>) -> bool {
+    todo!("implement negation-aware keyword detection")
+}
+
+/// Parses label suppression commands from a list of PR comments.
+///
+/// A suppression command is a line of the form:
+/// ```text
+/// <bot_mention> suppress: <label-name>
+/// ```
+/// The bot mention prefix comparison is case-insensitive.  Unknown commands are
+/// silently ignored.
+///
+/// # Arguments
+///
+/// * `comments` - All comments fetched from the pull request.
+/// * `bot_mention` - The bot mention prefix configured for this installation.
+///
+/// # Returns
+///
+/// A map from label name (trimmed, lowercase) to the login of the first commenter
+/// who issued the suppression command for that label.
+fn parse_suppressed_labels(comments: &[Comment], bot_mention: &str) -> HashMap<String, String> {
+    todo!("implement comment-based label suppression parsing")
+}
+
+/// Builds the body of an explanation comment for a keyword-triggered label.
+///
+/// The comment begins with a unique per-label HTML marker
+/// (`KEYWORD_LABEL_COMMENT_MARKER + label_name + " -->"`) so it can be found and
+/// managed idempotently.  It includes a human-readable explanation naming the label,
+/// stating that keywords triggered it, and showing the exact suppress command.
+///
+/// # Arguments
+///
+/// * `label_name` - The resolved label name (e.g. `"breaking-change"`).
+/// * `bot_mention` - The bot mention prefix (e.g. `"@merge-warden"`).
+fn build_keyword_label_comment(label_name: &str, bot_mention: &str) -> String {
+    todo!("implement keyword label explanation comment builder")
 }
 
 /// Discovers the WIP label name in use in a repository.

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -42,12 +42,18 @@ lazy_static! {
 
 /// Single-word negation tokens that, when found in the 5-word window immediately
 /// before a keyword match, indicate the keyword phrase is negated.
+///
+/// Punctuation is stripped from each token before comparison (see [`strip_punct`]),
+/// so `"no,"` and `"(no)"` both match `"no"`.
 const NEGATION_SINGLE_WORDS: &[&str] = &[
     "no", "not", "never", "without",
-    // Contractions (with and without apostrophe, since punctuation stripping may vary)
-    "don't", "dont", "doesn't", "doesnt",
-    "isn't", "isnt", "aren't", "arent",
-    "won't", "wont",
+    // Contractions — with and without apostrophe, since lookup happens after
+    // punctuation stripping which preserves `'` and `-`.
+    "don't", "dont", "doesn't", "doesnt", "isn't", "isnt", "aren't", "arent", "won't",
+    "wont",
+    // Note: "cannot", "neither", "nor" are deliberately excluded. "cannot" is
+    // ambiguous ("cannot wait to add a breaking change" is affirmative) and
+    // "neither"/"nor" require correlative context. Track as a future improvement.
 ];
 
 /// Common WIP label names used for discovery and cleanup.
@@ -480,31 +486,41 @@ pub async fn set_pull_request_labels_with_config<P: PullRequestProvider>(
 
         if *triggered && !is_suppressed {
             let expected_body = build_keyword_label_comment(label_name, bot_mention);
-            let already_up_to_date =
-                existing.len() == 1 && existing[0].1 == expected_body;
+            let already_up_to_date = existing.len() == 1 && existing[0].1 == expected_body;
 
             if !already_up_to_date {
-                // Delete all stale copies, then post a fresh one.
-                let mut all_deleted = true;
-                for (id, _) in &existing {
-                    if let Err(e) = provider.delete_comment(owner, repo, *id).await {
-                        warn!(
+                // Post the fresh comment first so the explanation always exists while
+                // the label is active.  This post-first approach ensures the comment
+                // is never permanently lost due to a transient API error that occurs
+                // after stale copies have already been deleted.
+                match provider
+                    .add_comment(owner, repo, pr.number, &expected_body)
+                    .await
+                {
+                    Ok(_) => {
+                        info!(
                             repository_owner = owner,
                             repository = repo,
                             pr_number = pr.number,
-                            comment_id = id,
                             label = %label_name,
-                            error = %e,
-                            "Failed to delete stale keyword label explanation comment"
+                            "Posted keyword label explanation comment"
                         );
-                        all_deleted = false;
+                        // Now that the fresh comment is in place, delete any stale copies.
+                        for (id, _) in &existing {
+                            if let Err(e) = provider.delete_comment(owner, repo, *id).await {
+                                warn!(
+                                    repository_owner = owner,
+                                    repository = repo,
+                                    pr_number = pr.number,
+                                    comment_id = id,
+                                    label = %label_name,
+                                    error = %e,
+                                    "Failed to delete stale keyword label explanation comment"
+                                );
+                            }
+                        }
                     }
-                }
-                if all_deleted {
-                    if let Err(e) = provider
-                        .add_comment(owner, repo, pr.number, &expected_body)
-                        .await
-                    {
+                    Err(e) => {
                         warn!(
                             repository_owner = owner,
                             repository = repo,
@@ -574,10 +590,9 @@ fn is_keyword_negated(text: &str, keyword_span: std::ops::Range<usize>) -> bool 
     let before = &text[..keyword_span.start];
 
     // Restrict look-back to current clause (stop at sentence / clause boundaries).
-    let clause_start = before
-        .rfind(['.', '!', '?', ';', '\n'])
-        .map(|i| i + 1)
-        .unwrap_or(0);
+    // Uses `find_clause_boundary` rather than a plain `rfind` so that `!` followed
+    // by `[` (a Markdown image link) is not treated as a sentence terminator.
+    let clause_start = find_clause_boundary(before).map(|i| i + 1).unwrap_or(0);
     let clause_before = &before[clause_start..];
 
     // Collect up to the last 5 whitespace-delimited tokens in this clause.
@@ -585,9 +600,43 @@ fn is_keyword_negated(text: &str, keyword_span: std::ops::Range<usize>) -> bool 
     let window_start = tokens.len().saturating_sub(5);
     let window = &tokens[window_start..];
 
+    // `text` is always lowercased by callers, so no `.to_lowercase()` allocation is needed.
+    // `strip_punct` removes leading/trailing punctuation so `"no,"` and `"(no)"` both match.
     window
         .iter()
-        .any(|tok| NEGATION_SINGLE_WORDS.contains(&tok.to_lowercase().as_str()))
+        .any(|tok| NEGATION_SINGLE_WORDS.contains(&strip_punct(tok)))
+}
+
+/// Finds the byte index of the rightmost clause-boundary character in `s`.
+///
+/// The characters `.`, `?`, `;`, and `\n` are always treated as clause boundaries.
+/// `!` is treated as a clause boundary **unless** it is immediately followed by `[`,
+/// which is the start of a Markdown image link (`![](url)`) and must not split the clause.
+fn find_clause_boundary(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    for i in (0..len).rev() {
+        match bytes[i] {
+            b'.' | b'?' | b';' | b'\n' => return Some(i),
+            b'!' => {
+                // `![` is Markdown image syntax — not a sentence boundary.
+                if i + 1 < len && bytes[i + 1] == b'[' {
+                    continue;
+                }
+                return Some(i);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Strips leading and trailing punctuation from a token, preserving apostrophes
+/// and hyphens that appear in negation contractions such as `"don't"` and `"won't"`.
+///
+/// Examples: `"no,"` → `"no"`, `"(no)"` → `"no"`, `"no:"` → `"no"`.
+fn strip_punct(s: &str) -> &str {
+    s.trim_matches(|c: char| !c.is_alphanumeric() && c != '\'' && c != '-')
 }
 
 /// Parses label suppression commands from a list of PR comments.

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -306,37 +306,110 @@ pub async fn set_pull_request_labels_with_config<P: PullRequestProvider>(
     let hotfix_label = keyword_labels.hotfix_label().to_string();
     let tech_debt_label = keyword_labels.tech_debt_label().to_string();
 
-    // Collect additional labels that need to be applied
+    let bot_mention = config
+        .map(|c| c.bot_mention.as_str())
+        .unwrap_or("@merge-warden");
+
+    // Fetch PR comments for suppression and explanation-comment management.
+    // If list_comments fails we gracefully continue with no suppression in effect.
+    let pr_comments = match provider.list_comments(owner, repo, pr.number).await {
+        Ok(comments) => comments,
+        Err(e) => {
+            warn!(
+                repository_owner = owner,
+                repository = repo,
+                pr_number = pr.number,
+                error = %e,
+                "Failed to fetch PR comments; proceeding without suppression"
+            );
+            Vec::new()
+        }
+    };
+
+    // Parse which labels have been suppressed by explicit user commands.
+    let suppressed = parse_suppressed_labels(&pr_comments, bot_mention);
+
+    // Fetch labels that are currently applied to the PR so we can remove suppressed ones.
+    let applied_labels = match provider.list_applied_labels(owner, repo, pr.number).await {
+        Ok(l) => l,
+        Err(e) => {
+            warn!(
+                repository_owner = owner,
+                repository = repo,
+                pr_number = pr.number,
+                error = %e,
+                "Failed to fetch applied labels; skipping suppression removal"
+            );
+            Vec::new()
+        }
+    };
+
+    // Determine which keyword labels are triggered using negation-aware detection.
+    let title_lower = pr.title.to_lowercase();
+    let body_lower = pr
+        .body
+        .as_deref()
+        .map(|b| b.to_lowercase())
+        .unwrap_or_default();
+
+    // Breaking change: `!:` in title is unconditional; keyword matches are negation-checked.
+    let breaking_from_exclamation = pr.title.contains("!:");
+    let breaking_from_keyword_title = !breaking_from_exclamation
+        && BREAKING_CHANGE_KEYWORD_RE
+            .find_iter(&title_lower)
+            .any(|m| !is_keyword_negated(&title_lower, m.range()));
+    let breaking_from_keyword_body = BREAKING_CHANGE_KEYWORD_RE
+        .find_iter(&body_lower)
+        .any(|m| !is_keyword_negated(&body_lower, m.range()));
+    let breaking_triggered =
+        breaking_from_exclamation || breaking_from_keyword_title || breaking_from_keyword_body;
+
+    let security_triggered = SECURITY_KEYWORD_RE
+        .find_iter(&body_lower)
+        .any(|m| !is_keyword_negated(&body_lower, m.range()));
+
+    let hotfix_triggered = HOTFIX_KEYWORD_RE
+        .find_iter(&body_lower)
+        .any(|m| !is_keyword_negated(&body_lower, m.range()));
+
+    let tech_debt_triggered = TECH_DEBT_KEYWORD_RE
+        .find_iter(&body_lower)
+        .any(|m| !is_keyword_negated(&body_lower, m.range()));
+
+    // (label_name, triggered) pairs drive both label application and comment lifecycle.
+    let keyword_label_states: Vec<(String, bool)> = vec![
+        (breaking_change_label, breaking_triggered),
+        (security_label, security_triggered),
+        (hotfix_label, hotfix_triggered),
+        (tech_debt_label, tech_debt_triggered),
+    ];
+
+    // Collect additional labels that need to be applied, skipping suppressed ones.
     let mut additional_labels = Vec::new();
 
-    // Check if PR is a breaking change
-    if pr.title.contains("!:") || pr.title.to_lowercase().contains("breaking change") {
-        additional_labels.push(breaking_change_label.clone());
-        labels.push(breaking_change_label.clone());
-    }
+    for (label_name, triggered) in &keyword_label_states {
+        let is_suppressed = suppressed.contains_key(label_name.as_str());
 
-    // Check PR description for keywords
-    if let Some(body) = &pr.body {
-        let body_lower = body.to_lowercase();
-
-        if body_lower.contains("breaking change") && !labels.contains(&breaking_change_label) {
-            additional_labels.push(breaking_change_label.clone());
-            labels.push(breaking_change_label.clone());
-        }
-
-        if body_lower.contains("security") || body_lower.contains("vulnerability") {
-            additional_labels.push(security_label.clone());
-            labels.push(security_label.clone());
-        }
-
-        if body_lower.contains("hotfix") {
-            additional_labels.push(hotfix_label.clone());
-            labels.push(hotfix_label.clone());
-        }
-
-        if body_lower.contains("technical debt") || body_lower.contains("tech debt") {
-            additional_labels.push(tech_debt_label.clone());
-            labels.push(tech_debt_label.clone());
+        if *triggered && !is_suppressed {
+            additional_labels.push(label_name.clone());
+            labels.push(label_name.clone());
+        } else if is_suppressed {
+            // Remove the label from the PR if it is currently applied.
+            if applied_labels.iter().any(|l| &l.name == label_name) {
+                if let Err(e) = provider
+                    .remove_label(owner, repo, pr.number, label_name)
+                    .await
+                {
+                    warn!(
+                        repository_owner = owner,
+                        repository = repo,
+                        pr_number = pr.number,
+                        label = %label_name,
+                        error = %e,
+                        "Failed to remove suppressed keyword label from pull request"
+                    );
+                }
+            }
         }
     }
 
@@ -378,6 +451,77 @@ pub async fn set_pull_request_labels_with_config<P: PullRequestProvider>(
         }
     }
 
+    // Manage explanation comments for each keyword label.
+    // Active (triggered and not suppressed): ensure the explanation comment is present
+    //   and up to date, replacing stale copies if needed.
+    // Inactive (not triggered) or suppressed: delete any stale explanation comment.
+    for (label_name, triggered) in &keyword_label_states {
+        let is_suppressed = suppressed.contains_key(label_name.as_str());
+        let label_marker = format!("{}{} -->", KEYWORD_LABEL_COMMENT_MARKER, label_name);
+
+        // Find all existing explanation comments for this label.
+        let existing: Vec<(u64, String)> = pr_comments
+            .iter()
+            .filter(|c| c.body.contains(&label_marker))
+            .map(|c| (c.id, c.body.clone()))
+            .collect();
+
+        if *triggered && !is_suppressed {
+            let expected_body = build_keyword_label_comment(label_name, bot_mention);
+            let already_up_to_date =
+                existing.len() == 1 && existing[0].1 == expected_body;
+
+            if !already_up_to_date {
+                // Delete all stale copies, then post a fresh one.
+                let mut all_deleted = true;
+                for (id, _) in &existing {
+                    if let Err(e) = provider.delete_comment(owner, repo, *id).await {
+                        warn!(
+                            repository_owner = owner,
+                            repository = repo,
+                            pr_number = pr.number,
+                            comment_id = id,
+                            label = %label_name,
+                            error = %e,
+                            "Failed to delete stale keyword label explanation comment"
+                        );
+                        all_deleted = false;
+                    }
+                }
+                if all_deleted {
+                    if let Err(e) = provider
+                        .add_comment(owner, repo, pr.number, &expected_body)
+                        .await
+                    {
+                        warn!(
+                            repository_owner = owner,
+                            repository = repo,
+                            pr_number = pr.number,
+                            label = %label_name,
+                            error = %e,
+                            "Failed to post keyword label explanation comment"
+                        );
+                    }
+                }
+            }
+        } else {
+            // Label is not active — delete any stale explanation comment.
+            for (id, _) in &existing {
+                if let Err(e) = provider.delete_comment(owner, repo, *id).await {
+                    warn!(
+                        repository_owner = owner,
+                        repository = repo,
+                        pr_number = pr.number,
+                        comment_id = id,
+                        label = %label_name,
+                        error = %e,
+                        "Failed to delete stale keyword label explanation comment"
+                    );
+                }
+            }
+        }
+    }
+
     Ok(labels)
 }
 
@@ -415,7 +559,23 @@ fn add_hardcoded_type_label(labels: &mut Vec<String>, pr_type: &str) {
 /// `true` when a negation word appears within the 5-word window before the keyword
 /// and within the same clause; `false` otherwise.
 fn is_keyword_negated(text: &str, keyword_span: std::ops::Range<usize>) -> bool {
-    todo!("implement negation-aware keyword detection")
+    let before = &text[..keyword_span.start];
+
+    // Restrict look-back to current clause (stop at sentence / clause boundaries).
+    let clause_start = before
+        .rfind(|c| matches!(c, '.' | '!' | '?' | ';' | '\n'))
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let clause_before = &before[clause_start..];
+
+    // Collect up to the last 5 whitespace-delimited tokens in this clause.
+    let tokens: Vec<&str> = clause_before.split_whitespace().collect();
+    let window_start = tokens.len().saturating_sub(5);
+    let window = &tokens[window_start..];
+
+    window
+        .iter()
+        .any(|tok| NEGATION_SINGLE_WORDS.contains(&tok.to_lowercase().as_str()))
 }
 
 /// Parses label suppression commands from a list of PR comments.
@@ -437,7 +597,29 @@ fn is_keyword_negated(text: &str, keyword_span: std::ops::Range<usize>) -> bool 
 /// A map from label name (trimmed, lowercase) to the login of the first commenter
 /// who issued the suppression command for that label.
 fn parse_suppressed_labels(comments: &[Comment], bot_mention: &str) -> HashMap<String, String> {
-    todo!("implement comment-based label suppression parsing")
+    let mut suppressed: HashMap<String, String> = HashMap::new();
+    let prefix = format!("{} suppress:", bot_mention.to_lowercase());
+
+    for comment in comments {
+        // Skip the bot's own explanation comments — they embed the suppress command
+        // as example text for the user, which must not be treated as a real command.
+        if comment.body.contains(KEYWORD_LABEL_COMMENT_MARKER) {
+            continue;
+        }
+
+        let login = comment.user.login.clone();
+        for line in comment.body.lines() {
+            let line_lower = line.trim().to_lowercase();
+            if let Some(rest) = line_lower.strip_prefix(&prefix) {
+                let label_name = rest.trim().to_string();
+                if !label_name.is_empty() {
+                    suppressed.entry(label_name).or_insert(login.clone());
+                }
+            }
+        }
+    }
+
+    suppressed
 }
 
 /// Builds the body of an explanation comment for a keyword-triggered label.
@@ -452,7 +634,18 @@ fn parse_suppressed_labels(comments: &[Comment], bot_mention: &str) -> HashMap<S
 /// * `label_name` - The resolved label name (e.g. `"breaking-change"`).
 /// * `bot_mention` - The bot mention prefix (e.g. `"@merge-warden"`).
 fn build_keyword_label_comment(label_name: &str, bot_mention: &str) -> String {
-    todo!("implement keyword label explanation comment builder")
+    format!(
+        "{label_marker} -->\n\
+         **Merge Warden** automatically applied the `{label}` label because keywords \
+         in this pull request triggered keyword detection.\n\n\
+         To suppress this label, add the following comment:\n\
+         ```\n\
+         {bot} suppress: {label}\n\
+         ```",
+        label_marker = format!("{}{}", KEYWORD_LABEL_COMMENT_MARKER, label_name),
+        label = label_name,
+        bot = bot_mention,
+    )
 }
 
 /// Discovers the WIP label name in use in a repository.

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -3793,16 +3793,101 @@ async fn test_not_negated_non_negation_word_containing_negation_substring() {
 
 #[test]
 async fn test_not_negated_word_ending_in_not() {
-    // "cannot" ends in "-not" but whole-word check must reject it
+    // "cannot" is NOT in the negation list (see labels.rs comment for rationale).
+    // "we cannot wait to add..." is affirmative — the negation list must not match it.
     let text = "we cannot wait to add a breaking change to the API";
     let span = find_span(text, "breaking change");
     assert!(
         !super::is_keyword_negated(text, span),
-        "'cannot' must not be treated as 'not'"
+        "'cannot' must not be treated as a negation word"
     );
 }
 
-// — Multiple negation words —
+// — Punctuation-attached negation tokens —
+
+#[test]
+async fn test_negated_no_with_trailing_comma() {
+    // "no," must be recognised as negation; punct stripping removes the comma.
+    let text = "no, this pr doesn't introduce a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'no,' (comma-attached) must negate"
+    );
+}
+
+#[test]
+async fn test_negated_no_in_parentheses() {
+    // "(no)" must be recognised as negation; punct stripping removes both parens.
+    let text = "this is (no) breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'(no)' (paren-wrapped) must negate"
+    );
+}
+
+#[test]
+async fn test_negated_no_with_trailing_colon() {
+    // "no:" must be recognised as negation; punct stripping removes the colon.
+    let text = "no: breaking change to the public api";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'no:' (colon-attached) must negate"
+    );
+}
+
+#[test]
+async fn test_negated_contraction_with_trailing_comma() {
+    // "don't," must still be recognised — commas appear after contractions in natural prose.
+    let text = "we don't, and have never, introduced a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'don't,' (comma after contraction) must negate"
+    );
+}
+
+// — Markdown image `!` must not act as a clause boundary —
+
+#[test]
+async fn test_negated_keyword_after_markdown_image_not_split_at_exclamation() {
+    // `!` followed by `[` is a Markdown image link, not a sentence terminator.
+    // The negation word before the image must still be in scope.
+    // Note: the URL must not contain `.` chars (which are sentence boundaries).
+    let text = "no ![screenshot](/img) breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'!' in markdown image link must not reset clause; 'no' before the image must negate"
+    );
+}
+
+#[test]
+async fn test_clause_boundary_exclamation_without_bracket_still_splits() {
+    // A bare `!` (not followed by `[`) IS a sentence boundary as before.
+    let text = "great! no breaking change";
+    let span = find_span(text, "breaking change");
+    // "no" is in the clause AFTER `!`, so it should still negate.
+    // The `!` terminates the prior clause — "no" is in the new clause.
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'no' in clause after bare '!' must still negate"
+    );
+}
+
+#[test]
+async fn test_negation_in_prior_clause_before_bare_exclamation_does_not_cross() {
+    // Negation word is in the clause that ends with `!`; keyword is in the next clause.
+    // The `!` boundary must prevent the negation from crossing into the next clause.
+    let text = "no! this introduces a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "'no!' in a prior clause must not negate 'breaking change' across the '!' boundary"
+    );
+}
 
 #[test]
 async fn test_negated_multiple_negation_words_in_window() {
@@ -4992,8 +5077,10 @@ async fn test_explanation_comment_stale_body_replaced_with_fresh_one() {
 }
 
 #[test]
-async fn test_explanation_comment_two_stale_copies_both_deleted_before_repost() {
-    // Two identical stale copies must both be deleted before one fresh comment is posted.
+async fn test_explanation_comment_two_stale_copies_both_replaced_with_fresh_one() {
+    // Two stale copies must both be deleted and exactly one fresh comment posted.
+    // The implementation posts the fresh comment first (post-first-then-delete approach)
+    // so the explanation is never permanently lost due to a transient delete failure.
     let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
     let stale_body = format!("{} old format v1", hotfix_marker);
     let stale1 = make_comment(80, "bot", &stale_body);

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -4243,6 +4243,48 @@ async fn test_negation_breaking_change_doesnt_variant_not_applied() {
         .contains(&"breaking-change".to_string()));
 }
 
+// Spec assertion: negation in the PR *title* must suppress breaking-change label.
+// The title "fix: no breaking change to the public api" contains the keyword
+// "breaking change" preceded by "no" — detection must be suppressed.
+#[test]
+async fn test_negation_breaking_change_in_title_not_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 102,
+        title: "fix: no breaking change to the public api".to_string(),
+        draft: false,
+        body: None,
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        !labels.contains(&"breaking-change".to_string()),
+        "'no breaking change' in title must not trigger label; got: {:?}",
+        labels
+    );
+    assert!(
+        !provider
+            .added_labels()
+            .contains(&"breaking-change".to_string()),
+        "add_labels must not be called with 'breaking-change' when negated in title"
+    );
+    // No explanation comment should be posted for breaking-change
+    let marker = format!("{}breaking-change -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(
+        !provider
+            .posted_comments()
+            .iter()
+            .any(|c| c.contains(&marker)),
+        "no breaking-change explanation comment must be posted when title negation suppresses detection"
+    );
+}
+
 #[test]
 async fn test_affirmative_breaking_change_in_body_applied() {
     let provider = KeywordLabelMockProvider::new(vec![], vec![]);

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -4,7 +4,9 @@ use merge_warden_developer_platforms::errors::Error;
 use std::sync::{Arc, Mutex};
 use tokio::test;
 
-use merge_warden_developer_platforms::models::{Comment, Label, PullRequest, PullRequestFile, Review, User};
+use merge_warden_developer_platforms::models::{
+    Comment, Label, PullRequest, PullRequestFile, Review, User,
+};
 use merge_warden_developer_platforms::PullRequestProvider;
 
 // ── WIP label test helpers ───────────────────────────────────────────────────
@@ -849,6 +851,7 @@ async fn test_determine_labels_with_scope() {
 }
 
 // Additional imports for smart label detection tests
+use super::{build_keyword_label_comment, is_keyword_negated, parse_suppressed_labels};
 use crate::config::{
     ChangeTypeLabelConfig, ConventionalCommitMappings, CurrentPullRequestValidationConfiguration,
     FallbackLabelSettings, KeywordLabelsConfig, LabelDetectionStrategy,
@@ -857,7 +860,6 @@ use crate::config::{
 use crate::labels::{
     set_pull_request_labels_with_config, LabelDetector, LabelManagementResult, LabelManager,
 };
-use super::{build_keyword_label_comment, is_keyword_negated, parse_suppressed_labels};
 use std::collections::HashMap;
 
 // Enhanced mock provider that supports repository labels for smart detection testing
@@ -909,7 +911,7 @@ impl PullRequestProvider for SmartMockGitProvider {
         _pr_number: u64,
         _comment: &str,
     ) -> Result<(), Error> {
-        unimplemented!("Not needed for this test")
+        Ok(())
     }
 
     async fn delete_comment(
@@ -918,7 +920,7 @@ impl PullRequestProvider for SmartMockGitProvider {
         _repo_name: &str,
         _comment_id: u64,
     ) -> Result<(), Error> {
-        unimplemented!("Not needed for this test")
+        Ok(())
     }
 
     async fn list_comments(
@@ -927,7 +929,7 @@ impl PullRequestProvider for SmartMockGitProvider {
         _repo_name: &str,
         _pr_number: u64,
     ) -> Result<Vec<Comment>, Error> {
-        unimplemented!("Not needed for this test")
+        Ok(vec![])
     }
 
     async fn list_available_labels(
@@ -963,7 +965,7 @@ impl PullRequestProvider for SmartMockGitProvider {
         _pr_number: u64,
         _label: &str,
     ) -> Result<(), Error> {
-        unimplemented!("Not needed for this test")
+        Ok(())
     }
 
     async fn list_applied_labels(
@@ -986,7 +988,7 @@ impl PullRequestProvider for SmartMockGitProvider {
         _output_summary: &str,
         _output_text: &str,
     ) -> Result<(), Error> {
-        unimplemented!("Not needed for this test")
+        Ok(())
     }
 
     async fn list_pr_reviews(
@@ -995,7 +997,7 @@ impl PullRequestProvider for SmartMockGitProvider {
         _repo_name: &str,
         _pr_number: u64,
     ) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> {
-        unimplemented!("Not needed for this test")
+        Ok(vec![])
     }
 
     async fn get_pull_request_files(
@@ -1004,7 +1006,7 @@ impl PullRequestProvider for SmartMockGitProvider {
         _repo_name: &str,
         _pr_number: u64,
     ) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> {
-        unimplemented!("Not needed for this test")
+        Ok(vec![])
     }
 }
 
@@ -3339,7 +3341,6 @@ async fn test_keyword_labels_no_config_uses_defaults() {
     );
 }
 
-
 // ── Full-featured mock for negation / suppression / explanation tests ────────
 
 struct KeywordLabelMockProvider {
@@ -3526,9 +3527,9 @@ fn make_comment(id: u64, login: &str, body: &str) -> Comment {
 
 /// Returns the byte range of `keyword` within `text`.  Panics when not found.
 fn find_span(text: &str, keyword: &str) -> std::ops::Range<usize> {
-    let start = text.find(keyword).unwrap_or_else(|| {
-        panic!("keyword '{keyword}' not found in text: '{text}'")
-    });
+    let start = text
+        .find(keyword)
+        .unwrap_or_else(|| panic!("keyword '{keyword}' not found in text: '{text}'"));
     start..start + keyword.len()
 }
 
@@ -3641,7 +3642,11 @@ async fn test_not_negated_clause_boundary_before_negation_word() {
 
 #[test]
 async fn test_parse_suppressed_single_command() {
-    let comments = vec![make_comment(1, "alice", "@merge-warden suppress: breaking-change")];
+    let comments = vec![make_comment(
+        1,
+        "alice",
+        "@merge-warden suppress: breaking-change",
+    )];
     let result = super::parse_suppressed_labels(&comments, "@merge-warden");
     assert!(
         result.contains_key("breaking-change"),
@@ -3672,7 +3677,11 @@ async fn test_parse_suppressed_two_labels_across_comments() {
 
 #[test]
 async fn test_parse_suppressed_unknown_command_ignored() {
-    let comments = vec![make_comment(1, "alice", "@merge-warden unknown: breaking-change")];
+    let comments = vec![make_comment(
+        1,
+        "alice",
+        "@merge-warden unknown: breaking-change",
+    )];
     let result = super::parse_suppressed_labels(&comments, "@merge-warden");
     assert!(result.is_empty(), "unknown commands must be ignored");
 }
@@ -3991,7 +4000,9 @@ async fn test_suppression_skips_label_application() {
         labels
     );
     assert!(
-        !provider.added_labels().contains(&"breaking-change".to_string()),
+        !provider
+            .added_labels()
+            .contains(&"breaking-change".to_string()),
         "suppressed label must not be passed to add_labels"
     );
 }
@@ -4003,7 +4014,8 @@ async fn test_suppression_removes_existing_label() {
         name: "security".to_string(),
         description: None,
     };
-    let provider = KeywordLabelMockProvider::new(vec![suppress_comment], vec![existing_security_label]);
+    let provider =
+        KeywordLabelMockProvider::new(vec![suppress_comment], vec![existing_security_label]);
     let config = CurrentPullRequestValidationConfiguration {
         bot_mention: "@merge-warden".to_string(),
         ..Default::default()

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -4,7 +4,7 @@ use merge_warden_developer_platforms::errors::Error;
 use std::sync::{Arc, Mutex};
 use tokio::test;
 
-use merge_warden_developer_platforms::models::{Comment, Label, PullRequest, Review, User};
+use merge_warden_developer_platforms::models::{Comment, Label, PullRequest, PullRequestFile, Review, User};
 use merge_warden_developer_platforms::PullRequestProvider;
 
 // ── WIP label test helpers ───────────────────────────────────────────────────
@@ -191,7 +191,7 @@ impl PullRequestProvider for MockGitProvider {
         _pr_number: u64,
         _comment: &str,
     ) -> Result<(), Error> {
-        unimplemented!("Not needed for this test")
+        Ok(())
     }
 
     async fn delete_comment(
@@ -200,7 +200,7 @@ impl PullRequestProvider for MockGitProvider {
         _repo_name: &str,
         _comment_id: u64,
     ) -> Result<(), Error> {
-        unimplemented!("Not needed for this test")
+        Ok(())
     }
 
     async fn list_comments(
@@ -209,7 +209,7 @@ impl PullRequestProvider for MockGitProvider {
         _repo_name: &str,
         _pr_number: u64,
     ) -> Result<Vec<Comment>, Error> {
-        unimplemented!("Not needed for this test")
+        Ok(vec![])
     }
 
     async fn list_available_labels(
@@ -308,7 +308,7 @@ impl PullRequestProvider for ErrorMockGitProvider {
         _pr_number: u64,
         _comment: &str,
     ) -> Result<(), Error> {
-        unimplemented!("Not needed for this test")
+        Ok(())
     }
 
     async fn delete_comment(
@@ -317,7 +317,7 @@ impl PullRequestProvider for ErrorMockGitProvider {
         _repo_name: &str,
         _comment_id: u64,
     ) -> Result<(), Error> {
-        unimplemented!("Not needed for this test")
+        Ok(())
     }
 
     async fn list_comments(
@@ -326,7 +326,7 @@ impl PullRequestProvider for ErrorMockGitProvider {
         _repo_name: &str,
         _pr_number: u64,
     ) -> Result<Vec<Comment>, Error> {
-        unimplemented!("Not needed for this test")
+        Ok(vec![])
     }
 
     async fn add_labels(
@@ -852,10 +852,12 @@ async fn test_determine_labels_with_scope() {
 use crate::config::{
     ChangeTypeLabelConfig, ConventionalCommitMappings, CurrentPullRequestValidationConfiguration,
     FallbackLabelSettings, KeywordLabelsConfig, LabelDetectionStrategy,
+    KEYWORD_LABEL_COMMENT_MARKER,
 };
 use crate::labels::{
     set_pull_request_labels_with_config, LabelDetector, LabelManagementResult, LabelManager,
 };
+use super::{build_keyword_label_comment, is_keyword_negated, parse_suppressed_labels};
 use std::collections::HashMap;
 
 // Enhanced mock provider that supports repository labels for smart detection testing
@@ -3334,5 +3336,887 @@ async fn test_keyword_labels_no_config_uses_defaults() {
         labels.contains(&"tech-debt".to_string()),
         "Default 'tech-debt' must be used when no config provided; got: {:?}",
         labels
+    );
+}
+
+
+// ── Full-featured mock for negation / suppression / explanation tests ────────
+
+struct KeywordLabelMockProvider {
+    /// Comments pre-loaded on the PR (returned by list_comments).
+    comments: Vec<Comment>,
+    /// Labels currently applied to the PR.
+    applied_labels: Arc<Mutex<Vec<Label>>>,
+    /// Bodies of all add_comment calls, in order.
+    add_comment_calls: Arc<Mutex<Vec<String>>>,
+    /// IDs of all delete_comment calls, in order.
+    delete_comment_calls: Arc<Mutex<Vec<u64>>>,
+    /// Names of all remove_label calls, in order.
+    remove_label_calls: Arc<Mutex<Vec<String>>>,
+    /// Names of all add_labels calls (flattened), in order.
+    add_label_calls: Arc<Mutex<Vec<String>>>,
+    /// Whether list_comments should return an error.
+    list_comments_fails: bool,
+}
+
+impl KeywordLabelMockProvider {
+    fn new(comments: Vec<Comment>, applied_labels: Vec<Label>) -> Self {
+        Self {
+            comments,
+            applied_labels: Arc::new(Mutex::new(applied_labels)),
+            add_comment_calls: Arc::new(Mutex::new(Vec::new())),
+            delete_comment_calls: Arc::new(Mutex::new(Vec::new())),
+            remove_label_calls: Arc::new(Mutex::new(Vec::new())),
+            add_label_calls: Arc::new(Mutex::new(Vec::new())),
+            list_comments_fails: false,
+        }
+    }
+
+    fn with_failing_list_comments(mut self) -> Self {
+        self.list_comments_fails = true;
+        self
+    }
+
+    fn added_labels(&self) -> Vec<String> {
+        self.add_label_calls.lock().unwrap().clone()
+    }
+
+    fn removed_labels(&self) -> Vec<String> {
+        self.remove_label_calls.lock().unwrap().clone()
+    }
+
+    fn posted_comments(&self) -> Vec<String> {
+        self.add_comment_calls.lock().unwrap().clone()
+    }
+
+    fn deleted_comment_ids(&self) -> Vec<u64> {
+        self.delete_comment_calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl PullRequestProvider for KeywordLabelMockProvider {
+    async fn get_pull_request(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+    ) -> Result<PullRequest, Error> {
+        unimplemented!("Not needed for this test")
+    }
+
+    async fn add_comment(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+        comment: &str,
+    ) -> Result<(), Error> {
+        self.add_comment_calls
+            .lock()
+            .unwrap()
+            .push(comment.to_string());
+        Ok(())
+    }
+
+    async fn delete_comment(&self, _owner: &str, _repo: &str, id: u64) -> Result<(), Error> {
+        self.delete_comment_calls.lock().unwrap().push(id);
+        Ok(())
+    }
+
+    async fn list_comments(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+    ) -> Result<Vec<Comment>, Error> {
+        if self.list_comments_fails {
+            return Err(Error::FailedToUpdatePullRequest(
+                "list_comments failed".to_string(),
+            ));
+        }
+        Ok(self.comments.clone())
+    }
+
+    async fn list_available_labels(&self, _owner: &str, _repo: &str) -> Result<Vec<Label>, Error> {
+        Ok(vec![])
+    }
+
+    async fn add_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+        labels: &[String],
+    ) -> Result<(), Error> {
+        self.add_label_calls
+            .lock()
+            .unwrap()
+            .extend(labels.iter().cloned());
+        Ok(())
+    }
+
+    async fn remove_label(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+        label: &str,
+    ) -> Result<(), Error> {
+        self.remove_label_calls
+            .lock()
+            .unwrap()
+            .push(label.to_string());
+        Ok(())
+    }
+
+    async fn list_applied_labels(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+    ) -> Result<Vec<Label>, Error> {
+        Ok(self.applied_labels.lock().unwrap().clone())
+    }
+
+    async fn update_pr_check_status(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+        _conclusion: &str,
+        _title: &str,
+        _summary: &str,
+        _text: &str,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn list_pr_reviews(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+    ) -> Result<Vec<Review>, Error> {
+        Ok(vec![])
+    }
+
+    async fn get_pull_request_files(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _number: u64,
+    ) -> Result<Vec<PullRequestFile>, Error> {
+        Ok(vec![])
+    }
+}
+
+// ── Helper functions ─────────────────────────────────────────────────────────
+
+fn make_comment(id: u64, login: &str, body: &str) -> Comment {
+    Comment {
+        id,
+        body: body.to_string(),
+        user: User {
+            id: id * 100,
+            login: login.to_string(),
+        },
+    }
+}
+
+/// Returns the byte range of `keyword` within `text`.  Panics when not found.
+fn find_span(text: &str, keyword: &str) -> std::ops::Range<usize> {
+    let start = text.find(keyword).unwrap_or_else(|| {
+        panic!("keyword '{keyword}' not found in text: '{text}'")
+    });
+    start..start + keyword.len()
+}
+
+// ── is_keyword_negated tests ─────────────────────────────────────────────────
+
+#[test]
+async fn test_negated_no_immediately_before_keyword() {
+    let text = "no breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'no' immediately before keyword must negate it"
+    );
+}
+
+#[test]
+async fn test_negated_not_in_window() {
+    let text = "this is not a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'not' in 5-word window must negate the keyword"
+    );
+}
+
+#[test]
+async fn test_negated_without_before_keyword() {
+    let text = "merged without any breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'without' must negate the keyword"
+    );
+}
+
+#[test]
+async fn test_negated_never_before_keyword() {
+    let text = "there is never a breaking change here";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'never' must negate the keyword"
+    );
+}
+
+#[test]
+async fn test_negated_contraction_dont() {
+    let text = "we don't have a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'don't' must negate the keyword"
+    );
+}
+
+#[test]
+async fn test_negated_contraction_doesnt() {
+    let text = "this pr doesn't introduce a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'doesn't' must negate the keyword"
+    );
+}
+
+#[test]
+async fn test_not_negated_when_no_negation_word_present() {
+    let text = "this introduces a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "no negation word must NOT negate"
+    );
+}
+
+#[test]
+async fn test_not_negated_when_negation_word_outside_5_word_window() {
+    // "no" is the first of 7 tokens before keyword — outside the 5-word window
+    let text = "no word1 word2 word3 word4 word5 breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "'no' more than 5 words before keyword must NOT negate"
+    );
+}
+
+#[test]
+async fn test_not_negated_non_negation_word_containing_negation_substring() {
+    // "annotated" contains "not" as a substring but is not a negation word
+    let text = "annotated breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "'annotated' must not be treated as a negation word"
+    );
+}
+
+#[test]
+async fn test_not_negated_clause_boundary_before_negation_word() {
+    // "no" is in a prior sentence; "breaking change" is in the next clause
+    let text = "there are no issues. this introduces a breaking change.";
+    let span = find_span(text, "breaking change");
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "'no' from a previous clause must not cross a clause boundary"
+    );
+}
+
+// ── parse_suppressed_labels tests ────────────────────────────────────────────
+
+#[test]
+async fn test_parse_suppressed_single_command() {
+    let comments = vec![make_comment(1, "alice", "@merge-warden suppress: breaking-change")];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(
+        result.contains_key("breaking-change"),
+        "should contain 'breaking-change'"
+    );
+    assert_eq!(result["breaking-change"], "alice");
+}
+
+#[test]
+async fn test_parse_suppressed_two_labels_same_comment() {
+    let body = "@merge-warden suppress: breaking-change\n@merge-warden suppress: security";
+    let comments = vec![make_comment(1, "bob", body)];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(result.contains_key("breaking-change"));
+    assert!(result.contains_key("security"));
+}
+
+#[test]
+async fn test_parse_suppressed_two_labels_across_comments() {
+    let comments = vec![
+        make_comment(1, "alice", "@merge-warden suppress: hotfix"),
+        make_comment(2, "bob", "@merge-warden suppress: tech-debt"),
+    ];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(result.contains_key("hotfix"));
+    assert!(result.contains_key("tech-debt"));
+}
+
+#[test]
+async fn test_parse_suppressed_unknown_command_ignored() {
+    let comments = vec![make_comment(1, "alice", "@merge-warden unknown: breaking-change")];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(result.is_empty(), "unknown commands must be ignored");
+}
+
+#[test]
+async fn test_parse_suppressed_non_mention_line_ignored() {
+    let comments = vec![make_comment(1, "alice", "just a normal comment")];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(
+        result.is_empty(),
+        "line not starting with bot_mention must be ignored"
+    );
+}
+
+#[test]
+async fn test_parse_suppressed_case_insensitive_bot_mention() {
+    let comments = vec![make_comment(1, "carol", "@MERGE-WARDEN suppress: security")];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(
+        result.contains_key("security"),
+        "bot_mention comparison must be case-insensitive"
+    );
+}
+
+#[test]
+async fn test_parse_suppressed_custom_bot_mention() {
+    let comments = vec![make_comment(1, "dave", "@acme-bot suppress: hotfix")];
+    let result = super::parse_suppressed_labels(&comments, "@acme-bot");
+    assert!(result.contains_key("hotfix"));
+}
+
+// ── build_keyword_label_comment tests ────────────────────────────────────────
+
+#[test]
+async fn test_build_keyword_label_comment_marker_present() {
+    let body = super::build_keyword_label_comment("breaking-change", "@merge-warden");
+    let expected_marker = format!("{}breaking-change -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(
+        body.contains(&expected_marker),
+        "comment must contain the per-label marker; got:\n{body}"
+    );
+}
+
+#[test]
+async fn test_build_keyword_label_comment_label_name_present() {
+    let body = super::build_keyword_label_comment("security", "@merge-warden");
+    assert!(
+        body.contains("security"),
+        "comment must mention the label name; got:\n{body}"
+    );
+}
+
+#[test]
+async fn test_build_keyword_label_comment_suppress_command_present() {
+    let body = super::build_keyword_label_comment("hotfix", "@merge-warden");
+    assert!(
+        body.contains("@merge-warden suppress: hotfix"),
+        "comment must include the suppress command; got:\n{body}"
+    );
+}
+
+#[test]
+async fn test_build_keyword_label_comment_custom_bot_mention() {
+    let body = super::build_keyword_label_comment("tech-debt", "@acme-bot");
+    assert!(
+        body.contains("@acme-bot suppress: tech-debt"),
+        "custom bot_mention must appear in suppress command; got:\n{body}"
+    );
+}
+
+// ── Negation-aware detection integration tests ───────────────────────────────
+
+#[test]
+async fn test_negation_breaking_change_in_body_not_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 10,
+        title: "fix: cleanup api".to_string(),
+        draft: false,
+        body: Some("This PR introduces no breaking changes.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        !labels.contains(&"breaking-change".to_string()),
+        "'no breaking changes' must not trigger label; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_affirmative_breaking_change_in_body_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 11,
+        title: "feat: remove api".to_string(),
+        draft: false,
+        body: Some("Breaking change: removed the old API endpoint.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        labels.contains(&"breaking-change".to_string()),
+        "affirmative breaking change must apply label; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_exclamation_colon_always_triggers_breaking_change() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 12,
+        title: "feat!: remove public api".to_string(),
+        draft: false,
+        body: Some("no breaking changes in the description".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        labels.contains(&"breaking-change".to_string()),
+        "'!:' in title must always trigger breaking-change; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_negation_security_in_body_not_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 13,
+        title: "fix: dep update".to_string(),
+        draft: false,
+        body: Some("There are no security vulnerabilities introduced.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        !labels.contains(&"security".to_string()),
+        "'no security vulnerabilities' must not trigger label; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_affirmative_security_in_body_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 14,
+        title: "fix: patch cve".to_string(),
+        draft: false,
+        body: Some("security: addresses cve-2025-1234".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        labels.contains(&"security".to_string()),
+        "affirmative security mention must apply label; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_negation_hotfix_in_body_not_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 15,
+        title: "fix: routine".to_string(),
+        draft: false,
+        body: Some("There is no hotfix required.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        !labels.contains(&"hotfix".to_string()),
+        "'no hotfix required' must not trigger label; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_affirmative_hotfix_in_body_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 16,
+        title: "fix: crash".to_string(),
+        draft: false,
+        body: Some("This is a hotfix for the production crash.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        labels.contains(&"hotfix".to_string()),
+        "affirmative hotfix mention must apply label; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_negation_tech_debt_in_body_not_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 17,
+        title: "refactor: cleanup".to_string(),
+        draft: false,
+        body: Some("not tech debt, this is a refactor.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        !labels.contains(&"tech-debt".to_string()),
+        "'not tech debt' must not trigger label; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_affirmative_tech_debt_reduces_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 18,
+        title: "refactor: reduce complexity".to_string(),
+        draft: false,
+        body: Some("reduces tech debt by cleaning up the module.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        labels.contains(&"tech-debt".to_string()),
+        "'reduces tech debt' is still about tech debt; got: {:?}",
+        labels
+    );
+}
+
+// ── Suppression integration tests ────────────────────────────────────────────
+
+#[test]
+async fn test_suppression_skips_label_application() {
+    let suppress_comment = make_comment(1, "alice", "@merge-warden suppress: breaking-change");
+    let provider = KeywordLabelMockProvider::new(vec![suppress_comment], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 20,
+        title: "feat!: remove endpoint".to_string(),
+        draft: false,
+        body: None,
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    assert!(
+        !labels.contains(&"breaking-change".to_string()),
+        "suppressed label must not be applied; got: {:?}",
+        labels
+    );
+    assert!(
+        !provider.added_labels().contains(&"breaking-change".to_string()),
+        "suppressed label must not be passed to add_labels"
+    );
+}
+
+#[test]
+async fn test_suppression_removes_existing_label() {
+    let suppress_comment = make_comment(1, "alice", "@merge-warden suppress: security");
+    let existing_security_label = Label {
+        name: "security".to_string(),
+        description: None,
+    };
+    let provider = KeywordLabelMockProvider::new(vec![suppress_comment], vec![existing_security_label]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 21,
+        title: "fix: patch".to_string(),
+        draft: false,
+        body: Some("security: addresses cve-2025-0001".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    assert!(
+        provider.removed_labels().contains(&"security".to_string()),
+        "suppressed label already on PR must be removed; removed: {:?}",
+        provider.removed_labels()
+    );
+}
+
+#[test]
+async fn test_suppression_multi_label() {
+    let body = "@merge-warden suppress: hotfix\n@merge-warden suppress: tech-debt";
+    let suppress_comment = make_comment(1, "alice", body);
+    let provider = KeywordLabelMockProvider::new(vec![suppress_comment], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 22,
+        title: "fix: urgent cleanup".to_string(),
+        draft: false,
+        body: Some("this is a hotfix that also reduces tech debt".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    assert!(
+        !labels.contains(&"hotfix".to_string()),
+        "suppressed hotfix must not be applied; got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"tech-debt".to_string()),
+        "suppressed tech-debt must not be applied; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_suppression_list_comments_failure_falls_back_gracefully() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]).with_failing_list_comments();
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 23,
+        title: "fix: crash".to_string(),
+        draft: false,
+        body: Some("This is a hotfix for production.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    assert!(
+        labels.contains(&"hotfix".to_string()),
+        "when list_comments fails, label must still be applied; got: {:?}",
+        labels
+    );
+}
+
+// ── Explanation comment lifecycle tests ──────────────────────────────────────
+
+#[test]
+async fn test_explanation_comment_posted_when_label_triggered() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 30,
+        title: "fix: crash".to_string(),
+        draft: false,
+        body: Some("This is a hotfix for the server crash.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    let posted = provider.posted_comments();
+    let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(
+        posted.iter().any(|c| c.contains(&hotfix_marker)),
+        "an explanation comment for 'hotfix' must be posted; posted: {:?}",
+        posted
+    );
+}
+
+#[test]
+async fn test_explanation_comment_idempotent_when_identical_exists() {
+    let expected_body = super::build_keyword_label_comment("hotfix", "@merge-warden");
+    let existing = make_comment(99, "merge-warden[bot]", &expected_body);
+    let provider = KeywordLabelMockProvider::new(vec![existing], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 31,
+        title: "fix: crash".to_string(),
+        draft: false,
+        body: Some("This is a hotfix for the server crash.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    assert!(
+        provider.posted_comments().is_empty(),
+        "identical existing comment must not trigger re-post; posted: {:?}",
+        provider.posted_comments()
+    );
+    assert!(
+        provider.deleted_comment_ids().is_empty(),
+        "identical existing comment must not be deleted; deleted: {:?}",
+        provider.deleted_comment_ids()
+    );
+}
+
+#[test]
+async fn test_explanation_comment_deleted_when_detection_clears() {
+    let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    let stale = make_comment(50, "bot", &format!("{} stale body", hotfix_marker));
+    let provider = KeywordLabelMockProvider::new(vec![stale], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    // PR body no longer mentions hotfix -> detection does not fire
+    let pr = PullRequest {
+        number: 32,
+        title: "fix: unrelated".to_string(),
+        draft: false,
+        body: Some("This PR fixes an unrelated issue.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    assert!(
+        provider.deleted_comment_ids().contains(&50),
+        "stale explanation comment must be deleted when detection clears; deleted: {:?}",
+        provider.deleted_comment_ids()
+    );
+}
+
+#[test]
+async fn test_explanation_comment_deleted_when_label_suppressed() {
+    let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    let explanation = make_comment(60, "bot", &format!("{} hotfix explanation", hotfix_marker));
+    let suppress = make_comment(61, "alice", "@merge-warden suppress: hotfix");
+    let provider = KeywordLabelMockProvider::new(vec![explanation, suppress], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 33,
+        title: "fix: crash".to_string(),
+        draft: false,
+        body: Some("This is a hotfix for production.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    assert!(
+        provider.deleted_comment_ids().contains(&60),
+        "explanation comment must be deleted when label is suppressed; deleted: {:?}",
+        provider.deleted_comment_ids()
     );
 }

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -247,7 +247,7 @@ impl PullRequestProvider for MockGitProvider {
         _pr_number: u64,
         _label: &str,
     ) -> Result<(), Error> {
-        unimplemented!("Not needed for this test")
+        Ok(())
     }
 
     async fn list_applied_labels(
@@ -270,7 +270,7 @@ impl PullRequestProvider for MockGitProvider {
         _output_summary: &str,
         _output_text: &str,
     ) -> Result<(), Error> {
-        unimplemented!("Not needed for this test")
+        Ok(())
     }
 
     async fn list_pr_reviews(
@@ -279,7 +279,7 @@ impl PullRequestProvider for MockGitProvider {
         _repo_name: &str,
         _pr_number: u64,
     ) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> {
-        unimplemented!("Not needed for this test")
+        Ok(vec![])
     }
 
     async fn get_pull_request_files(
@@ -288,7 +288,7 @@ impl PullRequestProvider for MockGitProvider {
         _repo_name: &str,
         _pr_number: u64,
     ) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> {
-        unimplemented!("Not needed for this test")
+        Ok(vec![])
     }
 }
 
@@ -3533,26 +3533,24 @@ fn find_span(text: &str, keyword: &str) -> std::ops::Range<usize> {
     start..start + keyword.len()
 }
 
-// ── is_keyword_negated tests ─────────────────────────────────────────────────
+// ── is_keyword_negated: comprehensive adversarial tests ──────────────────────
+// Tests every negation word, every boundary condition, and corner cases that
+// could expose bugs in the clause-scoping or tokenisation logic.
+
+// — Each negation word individually —
 
 #[test]
 async fn test_negated_no_immediately_before_keyword() {
     let text = "no breaking change";
     let span = find_span(text, "breaking change");
-    assert!(
-        super::is_keyword_negated(text, span),
-        "'no' immediately before keyword must negate it"
-    );
+    assert!(super::is_keyword_negated(text, span), "'no' must negate");
 }
 
 #[test]
 async fn test_negated_not_in_window() {
     let text = "this is not a breaking change";
     let span = find_span(text, "breaking change");
-    assert!(
-        super::is_keyword_negated(text, span),
-        "'not' in 5-word window must negate the keyword"
-    );
+    assert!(super::is_keyword_negated(text, span), "'not' must negate");
 }
 
 #[test]
@@ -3561,7 +3559,7 @@ async fn test_negated_without_before_keyword() {
     let span = find_span(text, "breaking change");
     assert!(
         super::is_keyword_negated(text, span),
-        "'without' must negate the keyword"
+        "'without' must negate"
     );
 }
 
@@ -3569,56 +3567,222 @@ async fn test_negated_without_before_keyword() {
 async fn test_negated_never_before_keyword() {
     let text = "there is never a breaking change here";
     let span = find_span(text, "breaking change");
-    assert!(
-        super::is_keyword_negated(text, span),
-        "'never' must negate the keyword"
-    );
+    assert!(super::is_keyword_negated(text, span), "'never' must negate");
 }
 
 #[test]
-async fn test_negated_contraction_dont() {
+async fn test_negated_dont_with_apostrophe() {
     let text = "we don't have a breaking change";
     let span = find_span(text, "breaking change");
-    assert!(
-        super::is_keyword_negated(text, span),
-        "'don't' must negate the keyword"
-    );
+    assert!(super::is_keyword_negated(text, span), "'don't' must negate");
 }
 
 #[test]
-async fn test_negated_contraction_doesnt() {
+async fn test_negated_doesnt_with_apostrophe() {
     let text = "this pr doesn't introduce a breaking change";
     let span = find_span(text, "breaking change");
     assert!(
         super::is_keyword_negated(text, span),
-        "'doesn't' must negate the keyword"
+        "'doesn't' must negate"
     );
 }
 
 #[test]
-async fn test_not_negated_when_no_negation_word_present() {
-    let text = "this introduces a breaking change";
+async fn test_negated_isnt_with_apostrophe() {
+    let text = "this isn't a breaking change";
     let span = find_span(text, "breaking change");
+    assert!(super::is_keyword_negated(text, span), "'isn't' must negate");
+}
+
+#[test]
+async fn test_negated_arent_with_apostrophe() {
+    let text =
+        "these aren't breaking changes to the api, but this is a breaking change in behavior";
+    // "breaking change" appears AFTER the clause-local "isn't" – find the second occurrence
+    let second_start = text.rfind("breaking change").unwrap();
+    let span = second_start..second_start + "breaking change".len();
+    // The second "breaking change" has no negation word before it in its clause
     assert!(
         !super::is_keyword_negated(text, span),
-        "no negation word must NOT negate"
+        "second 'breaking change' after affirmative context must NOT be negated"
     );
 }
 
 #[test]
-async fn test_not_negated_when_negation_word_outside_5_word_window() {
-    // "no" is the first of 7 tokens before keyword — outside the 5-word window
+async fn test_negated_wont_with_apostrophe() {
+    let text = "this won't cause a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(super::is_keyword_negated(text, span), "'won't' must negate");
+}
+
+#[test]
+async fn test_negated_dont_without_apostrophe() {
+    let text = "we dont have a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(super::is_keyword_negated(text, span), "'dont' must negate");
+}
+
+#[test]
+async fn test_negated_doesnt_without_apostrophe() {
+    let text = "this doesnt introduce a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'doesnt' must negate"
+    );
+}
+
+#[test]
+async fn test_negated_isnt_without_apostrophe() {
+    let text = "this isnt a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(super::is_keyword_negated(text, span), "'isnt' must negate");
+}
+
+#[test]
+async fn test_negated_arent_without_apostrophe() {
+    let text = "these arent breaking changes in the old sense; this is a breaking change";
+    // The semicolon resets the clause; the second "breaking change" has no negation in its clause.
+    let second_start = text.rfind("breaking change").unwrap();
+    let span = second_start..second_start + "breaking change".len();
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "semicolon boundary must prevent 'arent' from crossing to the next clause"
+    );
+}
+
+#[test]
+async fn test_negated_wont_without_apostrophe() {
+    let text = "this wont cause a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(super::is_keyword_negated(text, span), "'wont' must negate");
+}
+
+// — "does not" / "is not" two-word patterns covered by "not" single token —
+
+#[test]
+async fn test_negated_does_not_pattern() {
+    // "not" is the operative single-word negation token within the 5-word window
+    let text = "this does not introduce a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'does not' (via 'not' token) must negate"
+    );
+}
+
+#[test]
+async fn test_negated_is_not_pattern() {
+    let text = "this is not a breaking change at all";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'is not' (via 'not' token) must negate"
+    );
+}
+
+// — Window boundary conditions —
+
+#[test]
+async fn test_negated_at_exactly_5_word_boundary() {
+    // "no" is the 5th (and last) word in the window: "no w1 w2 w3 breaking change"
+    // Tokens before keyword: ["no", "w1", "w2", "w3"]  – only 4, so all in window.
+    // Actually with "no w1 w2 w3 breaking change":
+    //   before = "no w1 w2 w3 "
+    //   tokens = ["no", "w1", "w2", "w3"]  → len=4, window_start=max(0,4-5)=0 → window=all → "no" IS in window.
+    let text = "no w1 w2 w3 breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'no' within 4 preceding words must negate (all within 5-word window)"
+    );
+}
+
+#[test]
+async fn test_not_negated_when_negation_is_6th_word_before_keyword() {
+    // "no" is followed by 5 filler words → it's the 6th token before the keyword → outside window
     let text = "no word1 word2 word3 word4 word5 breaking change";
     let span = find_span(text, "breaking change");
     assert!(
         !super::is_keyword_negated(text, span),
-        "'no' more than 5 words before keyword must NOT negate"
+        "'no' 6 words before keyword must NOT negate (outside 5-word window)"
     );
 }
 
 #[test]
+async fn test_negated_at_exactly_5th_position() {
+    // 5 tokens before keyword; negation is the 1st → window_start = 0, all included
+    let text = "not w1 w2 w3 w4 breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'not' exactly 5 words before keyword must still negate"
+    );
+}
+
+// — Clause boundary conditions —
+
+#[test]
+async fn test_not_negated_clause_boundary_period_resets() {
+    // "no" is in a prior sentence; "breaking change" is in the next clause
+    let text = "there are no issues. this introduces a breaking change.";
+    let span = find_span(text, "breaking change");
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "period resets clause scope; 'no' from prior sentence must not negate"
+    );
+}
+
+#[test]
+async fn test_not_negated_clause_boundary_semicolon_between_negation_and_keyword() {
+    // Semicolon between "no" and "breaking change" resets the clause
+    let text = "no; breaking change was introduced here";
+    let span = find_span(text, "breaking change");
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "semicolon between negation and keyword must reset clause and prevent negation"
+    );
+}
+
+#[test]
+async fn test_not_negated_clause_boundary_newline_resets() {
+    // Newline acts as clause boundary
+    let text = "no issues here\nthis introduces a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "newline resets clause scope; 'no' before newline must not negate across it"
+    );
+}
+
+#[test]
+async fn test_negated_after_semicolon_clause_boundary() {
+    // "not" appears AFTER a semicolon, in the SAME clause as the keyword
+    let text = "all fine here; not a breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'not' in the same clause after a semicolon must negate"
+    );
+}
+
+// — No preceding text conditions —
+
+#[test]
+async fn test_not_negated_keyword_at_very_start_of_text() {
+    let text = "breaking change was introduced";
+    let span = find_span(text, "breaking change");
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "keyword at start of text with no preceding context must NOT be negated"
+    );
+}
+
+// — Non-negation substrings —
+
+#[test]
 async fn test_not_negated_non_negation_word_containing_negation_substring() {
-    // "annotated" contains "not" as a substring but is not a negation word
+    // "annotated" contains "not" as substring but whole-word comparison must reject it
     let text = "annotated breaking change";
     let span = find_span(text, "breaking change");
     assert!(
@@ -3628,17 +3792,72 @@ async fn test_not_negated_non_negation_word_containing_negation_substring() {
 }
 
 #[test]
-async fn test_not_negated_clause_boundary_before_negation_word() {
-    // "no" is in a prior sentence; "breaking change" is in the next clause
-    let text = "there are no issues. this introduces a breaking change.";
+async fn test_not_negated_word_ending_in_not() {
+    // "cannot" ends in "-not" but whole-word check must reject it
+    let text = "we cannot wait to add a breaking change to the API";
     let span = find_span(text, "breaking change");
     assert!(
         !super::is_keyword_negated(text, span),
-        "'no' from a previous clause must not cross a clause boundary"
+        "'cannot' must not be treated as 'not'"
     );
 }
 
-// ── parse_suppressed_labels tests ────────────────────────────────────────────
+// — Multiple negation words —
+
+#[test]
+async fn test_negated_multiple_negation_words_in_window() {
+    // Belt AND suspenders: two negation words in the window
+    let text = "not no breaking change";
+    let span = find_span(text, "breaking change");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "multiple negation words in window must still negate"
+    );
+}
+
+// — Applied to different keyword types —
+
+#[test]
+async fn test_negated_security_keyword() {
+    let text = "there is no security vulnerability here";
+    let span = find_span(text, "security");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'no security' must negate"
+    );
+}
+
+#[test]
+async fn test_not_negated_affirmative_security_keyword() {
+    let text = "this addresses a security vulnerability";
+    let span = find_span(text, "security");
+    assert!(
+        !super::is_keyword_negated(text, span),
+        "affirmative security context must NOT negate"
+    );
+}
+
+#[test]
+async fn test_negated_hotfix_keyword() {
+    let text = "this is not a hotfix";
+    let span = find_span(text, "hotfix");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'not a hotfix' must negate"
+    );
+}
+
+#[test]
+async fn test_negated_tech_debt_keyword() {
+    let text = "without tech debt this time";
+    let span = find_span(text, "tech debt");
+    assert!(
+        super::is_keyword_negated(text, span),
+        "'without tech debt' must negate"
+    );
+}
+
+// ── parse_suppressed_labels: comprehensive adversarial tests ─────────────────
 
 #[test]
 async fn test_parse_suppressed_single_command() {
@@ -3648,11 +3867,11 @@ async fn test_parse_suppressed_single_command() {
         "@merge-warden suppress: breaking-change",
     )];
     let result = super::parse_suppressed_labels(&comments, "@merge-warden");
-    assert!(
-        result.contains_key("breaking-change"),
-        "should contain 'breaking-change'"
+    assert_eq!(
+        result.get("breaking-change").map(String::as_str),
+        Some("alice"),
+        "single suppress command must record commenter login"
     );
-    assert_eq!(result["breaking-change"], "alice");
 }
 
 #[test]
@@ -3660,8 +3879,15 @@ async fn test_parse_suppressed_two_labels_same_comment() {
     let body = "@merge-warden suppress: breaking-change\n@merge-warden suppress: security";
     let comments = vec![make_comment(1, "bob", body)];
     let result = super::parse_suppressed_labels(&comments, "@merge-warden");
-    assert!(result.contains_key("breaking-change"));
-    assert!(result.contains_key("security"));
+    assert!(
+        result.contains_key("breaking-change"),
+        "breaking-change must be suppressed"
+    );
+    assert!(
+        result.contains_key("security"),
+        "security must be suppressed"
+    );
+    assert_eq!(result.len(), 2, "must have exactly 2 entries");
 }
 
 #[test]
@@ -3673,86 +3899,258 @@ async fn test_parse_suppressed_two_labels_across_comments() {
     let result = super::parse_suppressed_labels(&comments, "@merge-warden");
     assert!(result.contains_key("hotfix"));
     assert!(result.contains_key("tech-debt"));
+    assert_eq!(result["hotfix"], "alice");
+    assert_eq!(result["tech-debt"], "bob");
 }
 
 #[test]
-async fn test_parse_suppressed_unknown_command_ignored() {
+async fn test_parse_suppressed_unknown_command_silently_ignored() {
     let comments = vec![make_comment(
         1,
         "alice",
         "@merge-warden unknown: breaking-change",
     )];
     let result = super::parse_suppressed_labels(&comments, "@merge-warden");
-    assert!(result.is_empty(), "unknown commands must be ignored");
+    assert!(
+        result.is_empty(),
+        "unrecognised command must produce no entries"
+    );
 }
 
 #[test]
 async fn test_parse_suppressed_non_mention_line_ignored() {
-    let comments = vec![make_comment(1, "alice", "just a normal comment")];
+    let comments = vec![make_comment(
+        1,
+        "alice",
+        "just a normal comment with no bot mention",
+    )];
     let result = super::parse_suppressed_labels(&comments, "@merge-warden");
     assert!(
         result.is_empty(),
-        "line not starting with bot_mention must be ignored"
+        "non-mention line must produce no entries"
     );
 }
 
 #[test]
 async fn test_parse_suppressed_case_insensitive_bot_mention() {
+    // Bot mention prefix is case-insensitive per spec
     let comments = vec![make_comment(1, "carol", "@MERGE-WARDEN suppress: security")];
     let result = super::parse_suppressed_labels(&comments, "@merge-warden");
     assert!(
         result.contains_key("security"),
-        "bot_mention comparison must be case-insensitive"
+        "uppercase bot mention must still match"
     );
+    assert_eq!(result["security"], "carol");
 }
 
 #[test]
 async fn test_parse_suppressed_custom_bot_mention() {
     let comments = vec![make_comment(1, "dave", "@acme-bot suppress: hotfix")];
     let result = super::parse_suppressed_labels(&comments, "@acme-bot");
-    assert!(result.contains_key("hotfix"));
+    assert!(
+        result.contains_key("hotfix"),
+        "custom bot mention must work"
+    );
+    // The default @merge-warden prefix must NOT match @acme-bot commands
+    let result2 = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(
+        result2.is_empty(),
+        "wrong bot mention prefix must not match"
+    );
 }
 
-// ── build_keyword_label_comment tests ────────────────────────────────────────
+#[test]
+async fn test_parse_suppressed_leading_whitespace_on_line_still_matches() {
+    // line.trim() strips leading whitespace before prefix comparison
+    let body = "   @merge-warden suppress: breaking-change";
+    let comments = vec![make_comment(1, "eve", body)];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(
+        result.contains_key("breaking-change"),
+        "leading whitespace on line must be trimmed before matching"
+    );
+}
 
 #[test]
-async fn test_build_keyword_label_comment_marker_present() {
+async fn test_parse_suppressed_label_name_with_trailing_whitespace_is_trimmed() {
+    // rest.trim() must remove trailing spaces from the label name
+    let body = "@merge-warden suppress: hotfix   ";
+    let comments = vec![make_comment(1, "frank", body)];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(
+        result.contains_key("hotfix"),
+        "trailing whitespace after label name must be trimmed"
+    );
+    assert!(
+        !result.contains_key("hotfix   "),
+        "key must not have trailing whitespace"
+    );
+}
+
+#[test]
+async fn test_parse_suppressed_uppercase_suppress_command_works() {
+    // The entire line is lowercased so "SUPPRESS:" must match "suppress:"
+    let body = "@merge-warden SUPPRESS: security";
+    let comments = vec![make_comment(1, "grace", body)];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(
+        result.contains_key("security"),
+        "SUPPRESS in uppercase must be treated same as suppress"
+    );
+}
+
+#[test]
+async fn test_parse_suppressed_empty_label_name_after_colon_ignored() {
+    // "@merge-warden suppress: " followed by nothing → empty label → must be silently ignored
+    let body = "@merge-warden suppress: ";
+    let comments = vec![make_comment(1, "harry", body)];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(
+        result.is_empty(),
+        "empty label name after colon must be ignored, not inserted"
+    );
+}
+
+#[test]
+async fn test_parse_suppressed_first_commenter_wins_for_same_label() {
+    // Two different people both suppress the same label; first commenter must win
+    let comments = vec![
+        make_comment(1, "alice", "@merge-warden suppress: breaking-change"),
+        make_comment(2, "bob", "@merge-warden suppress: breaking-change"),
+    ];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert_eq!(
+        result.get("breaking-change").map(String::as_str),
+        Some("alice"),
+        "first commenter must win when same label is suppressed multiple times"
+    );
+    assert_eq!(result.len(), 1, "must have exactly one entry for the label");
+}
+
+#[test]
+async fn test_parse_suppressed_bots_own_explanation_comment_is_skipped() {
+    // The bot's explanation comment embeds the suppress command as example text.
+    // It must be filtered out to prevent the bot from suppressing its own label.
+    let bot_comment_body = super::build_keyword_label_comment("hotfix", "@merge-warden");
+    assert!(
+        bot_comment_body.contains("@merge-warden suppress: hotfix"),
+        "sanity: bot comment body must contain suppress command as example"
+    );
+    let comments = vec![make_comment(1, "merge-warden[bot]", &bot_comment_body)];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(
+        result.is_empty(),
+        "the bot's own explanation comment must be skipped and must not trigger suppression"
+    );
+}
+
+#[test]
+async fn test_parse_suppressed_mixed_comment_some_commands_some_not() {
+    // A comment that has both a valid suppress command and unrelated lines
+    let body = "Looking good overall!\n@merge-warden suppress: hotfix\nPlease add more tests.";
+    let comments = vec![make_comment(1, "reviewer", body)];
+    let result = super::parse_suppressed_labels(&comments, "@merge-warden");
+    assert!(
+        result.contains_key("hotfix"),
+        "suppress command among other text must be recognized"
+    );
+    assert_eq!(result.len(), 1);
+}
+
+// ── build_keyword_label_comment: comprehensive adversarial tests ───────────────
+
+#[test]
+async fn test_build_keyword_label_comment_marker_is_first_line() {
+    // The KEYWORD_LABEL_COMMENT_MARKER must appear on the VERY FIRST LINE,
+    // not buried somewhere in the body.
     let body = super::build_keyword_label_comment("breaking-change", "@merge-warden");
-    let expected_marker = format!("{}breaking-change -->", KEYWORD_LABEL_COMMENT_MARKER);
-    assert!(
-        body.contains(&expected_marker),
-        "comment must contain the per-label marker; got:\n{body}"
+    let first_line = body
+        .lines()
+        .next()
+        .expect("comment must have at least one line");
+    let expected = format!("{}breaking-change -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert_eq!(
+        first_line, expected,
+        "marker must be exactly the first line of the comment body"
     );
 }
 
 #[test]
-async fn test_build_keyword_label_comment_label_name_present() {
+async fn test_build_keyword_label_comment_marker_includes_label_name() {
     let body = super::build_keyword_label_comment("security", "@merge-warden");
+    let marker = format!("{}security -->", KEYWORD_LABEL_COMMENT_MARKER);
     assert!(
-        body.contains("security"),
-        "comment must mention the label name; got:\n{body}"
+        body.contains(&marker),
+        "comment must contain the per-label marker with label name; got:\n{body}"
     );
 }
 
 #[test]
-async fn test_build_keyword_label_comment_suppress_command_present() {
+async fn test_build_keyword_label_comment_suppress_command_in_code_fence() {
+    // The suppress command must be inside a ``` code fence so users can easily copy it
     let body = super::build_keyword_label_comment("hotfix", "@merge-warden");
+    let lines: Vec<&str> = body.lines().collect();
+    // Find the opening code fence
+    let fence_pos = lines
+        .iter()
+        .position(|l| l.trim() == "```")
+        .expect("comment must contain a ``` code fence");
+    // The suppress command must appear after the fence
+    let after_fence = &lines[fence_pos + 1..];
     assert!(
-        body.contains("@merge-warden suppress: hotfix"),
-        "comment must include the suppress command; got:\n{body}"
+        after_fence
+            .iter()
+            .any(|l| l.trim() == "@merge-warden suppress: hotfix"),
+        "suppress command must appear inside the code fence; got:\n{body}"
     );
 }
 
 #[test]
-async fn test_build_keyword_label_comment_custom_bot_mention() {
-    let body = super::build_keyword_label_comment("tech-debt", "@acme-bot");
+async fn test_build_keyword_label_comment_suppress_command_reflects_label_name() {
+    let body = super::build_keyword_label_comment("tech-debt", "@merge-warden");
     assert!(
-        body.contains("@acme-bot suppress: tech-debt"),
-        "custom bot_mention must appear in suppress command; got:\n{body}"
+        body.contains("@merge-warden suppress: tech-debt"),
+        "suppress command must use the exact label name; got:\n{body}"
+    );
+}
+
+#[test]
+async fn test_build_keyword_label_comment_custom_bot_mention_on_first_line_marker() {
+    let body = super::build_keyword_label_comment("hotfix", "@acme-bot");
+    let first_line = body.lines().next().unwrap();
+    let expected_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert_eq!(
+        first_line, expected_marker,
+        "marker on first line must use the correct format"
+    );
+    assert!(
+        body.contains("@acme-bot suppress: hotfix"),
+        "suppress command must use the custom bot mention; got:\n{body}"
+    );
+}
+
+#[test]
+async fn test_build_keyword_label_comment_different_labels_produce_different_markers() {
+    let body_a = super::build_keyword_label_comment("security", "@merge-warden");
+    let body_b = super::build_keyword_label_comment("hotfix", "@merge-warden");
+    let marker_a = format!("{}security -->", KEYWORD_LABEL_COMMENT_MARKER);
+    let marker_b = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(body_a.contains(&marker_a));
+    assert!(
+        !body_a.contains(&marker_b),
+        "security comment must NOT contain hotfix marker"
+    );
+    assert!(body_b.contains(&marker_b));
+    assert!(
+        !body_b.contains(&marker_a),
+        "hotfix comment must NOT contain security marker"
     );
 }
 
 // ── Negation-aware detection integration tests ───────────────────────────────
+// These tests exercise set_pull_request_labels_with_config end-to-end.
+// They assert BOTH the return value AND the actual mock provider call record
+// to ensure the implementation does not just lie about what it applied.
 
 #[test]
 async fn test_negation_breaking_change_in_body_not_applied() {
@@ -3773,9 +4171,76 @@ async fn test_negation_breaking_change_in_body_not_applied() {
         .unwrap();
     assert!(
         !labels.contains(&"breaking-change".to_string()),
-        "'no breaking changes' must not trigger label; got: {:?}",
+        "'no breaking changes' must not trigger label (return value); got: {:?}",
         labels
     );
+    assert!(
+        !provider
+            .added_labels()
+            .contains(&"breaking-change".to_string()),
+        "add_labels must not be called with 'breaking-change' when negated"
+    );
+    // Explanation comment must NOT be posted for breaking-change
+    let marker = format!("{}breaking-change -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(
+        !provider
+            .posted_comments()
+            .iter()
+            .any(|c| c.contains(&marker)),
+        "no breaking-change explanation comment must be posted when detection is negated"
+    );
+    // Type label 'bug' must still be applied (proves the function ran properly)
+    assert!(
+        labels.contains(&"bug".to_string()),
+        "type label 'bug' must still be applied; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_negation_breaking_change_without_variant_not_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 100,
+        title: "fix: api update".to_string(),
+        draft: false,
+        body: Some("This was merged without breaking changes to the API.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(!labels.contains(&"breaking-change".to_string()));
+    assert!(!provider
+        .added_labels()
+        .contains(&"breaking-change".to_string()));
+}
+
+#[test]
+async fn test_negation_breaking_change_doesnt_variant_not_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 101,
+        title: "fix: migration".to_string(),
+        draft: false,
+        body: Some("This PR doesn't introduce any breaking change to the public API.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(!labels.contains(&"breaking-change".to_string()));
+    assert!(!provider
+        .added_labels()
+        .contains(&"breaking-change".to_string()));
 }
 
 #[test]
@@ -3797,19 +4262,37 @@ async fn test_affirmative_breaking_change_in_body_applied() {
         .unwrap();
     assert!(
         labels.contains(&"breaking-change".to_string()),
-        "affirmative breaking change must apply label; got: {:?}",
+        "affirmative breaking change must apply label (return value); got: {:?}",
         labels
+    );
+    assert!(
+        provider
+            .added_labels()
+            .contains(&"breaking-change".to_string()),
+        "add_labels must be called with 'breaking-change' for affirmative body"
+    );
+    // Explanation comment must be posted
+    let marker = format!("{}breaking-change -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(
+        provider
+            .posted_comments()
+            .iter()
+            .any(|c| c.contains(&marker)),
+        "explanation comment for breaking-change must be posted; posted: {:?}",
+        provider.posted_comments()
     );
 }
 
 #[test]
-async fn test_exclamation_colon_always_triggers_breaking_change() {
+async fn test_exclamation_colon_always_triggers_breaking_change_even_with_negated_body() {
+    // This is the critical test: "!:" in title is unconditional.
+    // Even if the body says "no breaking changes", the title marker wins.
     let provider = KeywordLabelMockProvider::new(vec![], vec![]);
     let pr = PullRequest {
         number: 12,
         title: "feat!: remove public api".to_string(),
         draft: false,
-        body: Some("no breaking changes in the description".to_string()),
+        body: Some("no breaking changes in the description whatsoever".to_string()),
         author: Some(User {
             id: 1,
             login: "dev".to_string(),
@@ -3821,9 +4304,44 @@ async fn test_exclamation_colon_always_triggers_breaking_change() {
         .unwrap();
     assert!(
         labels.contains(&"breaking-change".to_string()),
-        "'!:' in title must always trigger breaking-change; got: {:?}",
+        "'!:' in title must always trigger breaking-change regardless of negated body; got: {:?}",
         labels
     );
+    assert!(
+        provider
+            .added_labels()
+            .contains(&"breaking-change".to_string()),
+        "add_labels must be called with 'breaking-change' for '!:' title"
+    );
+}
+
+#[test]
+async fn test_body_with_both_negated_and_affirmative_breaking_change_triggers_label() {
+    // .any() on the regex iterator means a SINGLE non-negated match triggers the label.
+    // "no breaking change" is negated, but "this is a breaking change" is not.
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 102,
+        title: "refactor: api update".to_string(),
+        draft: false,
+        body: Some(
+            "no breaking change in the v1 API. However, this includes a breaking change in the CLI interface."
+                .to_string(),
+        ),
+        author: Some(User { id: 1, login: "dev".to_string() }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        labels.contains(&"breaking-change".to_string()),
+        "body with one negated and one affirmative match must still trigger label; got: {:?}",
+        labels
+    );
+    assert!(provider
+        .added_labels()
+        .contains(&"breaking-change".to_string()));
 }
 
 #[test]
@@ -3848,6 +4366,33 @@ async fn test_negation_security_in_body_not_applied() {
         "'no security vulnerabilities' must not trigger label; got: {:?}",
         labels
     );
+    assert!(!provider.added_labels().contains(&"security".to_string()));
+    let marker = format!("{}security -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(!provider
+        .posted_comments()
+        .iter()
+        .any(|c| c.contains(&marker)));
+}
+
+#[test]
+async fn test_negation_no_security_issues_in_body_not_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 103,
+        title: "chore: bump deps".to_string(),
+        draft: false,
+        body: Some("no security issues found in this update".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(!labels.contains(&"security".to_string()));
+    assert!(!provider.added_labels().contains(&"security".to_string()));
 }
 
 #[test]
@@ -3871,6 +4416,16 @@ async fn test_affirmative_security_in_body_applied() {
         labels.contains(&"security".to_string()),
         "affirmative security mention must apply label; got: {:?}",
         labels
+    );
+    assert!(provider.added_labels().contains(&"security".to_string()));
+    let marker = format!("{}security -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(
+        provider
+            .posted_comments()
+            .iter()
+            .any(|c| c.contains(&marker)),
+        "explanation comment for security must be posted; posted: {:?}",
+        provider.posted_comments()
     );
 }
 
@@ -3896,6 +4451,12 @@ async fn test_negation_hotfix_in_body_not_applied() {
         "'no hotfix required' must not trigger label; got: {:?}",
         labels
     );
+    assert!(!provider.added_labels().contains(&"hotfix".to_string()));
+    let marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(!provider
+        .posted_comments()
+        .iter()
+        .any(|c| c.contains(&marker)));
 }
 
 #[test]
@@ -3920,6 +4481,15 @@ async fn test_affirmative_hotfix_in_body_applied() {
         "affirmative hotfix mention must apply label; got: {:?}",
         labels
     );
+    assert!(provider.added_labels().contains(&"hotfix".to_string()));
+    let marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(
+        provider
+            .posted_comments()
+            .iter()
+            .any(|c| c.contains(&marker)),
+        "explanation comment for hotfix must be posted"
+    );
 }
 
 #[test]
@@ -3929,7 +4499,7 @@ async fn test_negation_tech_debt_in_body_not_applied() {
         number: 17,
         title: "refactor: cleanup".to_string(),
         draft: false,
-        body: Some("not tech debt, this is a refactor.".to_string()),
+        body: Some("not tech debt, this is a deliberate refactor.".to_string()),
         author: Some(User {
             id: 1,
             login: "dev".to_string(),
@@ -3944,10 +4514,32 @@ async fn test_negation_tech_debt_in_body_not_applied() {
         "'not tech debt' must not trigger label; got: {:?}",
         labels
     );
+    assert!(!provider.added_labels().contains(&"tech-debt".to_string()));
+}
+
+#[test]
+async fn test_negation_not_technical_debt_in_body_not_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 104,
+        title: "refactor: extract module".to_string(),
+        draft: false,
+        body: Some("This is not technical debt, it is a planned refactor.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(!labels.contains(&"tech-debt".to_string()));
 }
 
 #[test]
 async fn test_affirmative_tech_debt_reduces_applied() {
+    // "reduces tech debt" is STILL about tech debt – not negated
     let provider = KeywordLabelMockProvider::new(vec![], vec![]);
     let pr = PullRequest {
         number: 18,
@@ -3965,12 +4557,37 @@ async fn test_affirmative_tech_debt_reduces_applied() {
         .unwrap();
     assert!(
         labels.contains(&"tech-debt".to_string()),
-        "'reduces tech debt' is still about tech debt; got: {:?}",
+        "'reduces tech debt' is still about tech debt and must trigger label; got: {:?}",
+        labels
+    );
+    assert!(provider.added_labels().contains(&"tech-debt".to_string()));
+}
+
+#[test]
+async fn test_affirmative_technical_debt_in_body_applied() {
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let pr = PullRequest {
+        number: 105,
+        title: "fix: cleanup".to_string(),
+        draft: false,
+        body: Some("This PR introduces some technical debt to ship faster.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, None)
+        .await
+        .unwrap();
+    assert!(
+        labels.contains(&"tech-debt".to_string()),
+        "affirmative technical-debt mention must apply label; got: {:?}",
         labels
     );
 }
 
-// ── Suppression integration tests ────────────────────────────────────────────
+// ── Suppression integration tests ─────────────────────────────────────────────
 
 #[test]
 async fn test_suppression_skips_label_application() {
@@ -3994,21 +4611,33 @@ async fn test_suppression_skips_label_application() {
     let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
         .await
         .unwrap();
+    // Return value must not include the suppressed label
     assert!(
         !labels.contains(&"breaking-change".to_string()),
-        "suppressed label must not be applied; got: {:?}",
+        "suppressed label must not appear in return value; got: {:?}",
         labels
     );
+    // add_labels must not have been called with the suppressed label
     assert!(
         !provider
             .added_labels()
             .contains(&"breaking-change".to_string()),
-        "suppressed label must not be passed to add_labels"
+        "suppressed label must not be passed to add_labels; added: {:?}",
+        provider.added_labels()
+    );
+    // Explanation comment must NOT be posted for a suppressed label
+    let marker = format!("{}breaking-change -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(
+        !provider
+            .posted_comments()
+            .iter()
+            .any(|c| c.contains(&marker)),
+        "explanation comment must not be posted for suppressed label"
     );
 }
 
 #[test]
-async fn test_suppression_removes_existing_label() {
+async fn test_suppression_removes_existing_label_from_pr() {
     let suppress_comment = make_comment(1, "alice", "@merge-warden suppress: security");
     let existing_security_label = Label {
         name: "security".to_string(),
@@ -4036,16 +4665,94 @@ async fn test_suppression_removes_existing_label() {
         .unwrap();
     assert!(
         provider.removed_labels().contains(&"security".to_string()),
-        "suppressed label already on PR must be removed; removed: {:?}",
+        "suppressed label already on PR must be removed via remove_label; removed: {:?}",
+        provider.removed_labels()
+    );
+    // And it must NOT be re-added
+    assert!(
+        !provider.added_labels().contains(&"security".to_string()),
+        "suppressed label must not be re-added after removal"
+    );
+}
+
+#[test]
+async fn test_suppression_does_not_call_remove_when_label_not_currently_applied() {
+    // If the label is suppressed but not currently on the PR, remove_label must not be called.
+    // Calling remove_label when the label isn't there wastes an API call.
+    let suppress_comment = make_comment(1, "alice", "@merge-warden suppress: hotfix");
+    // applied_labels is EMPTY – hotfix is not currently on the PR
+    let provider = KeywordLabelMockProvider::new(vec![suppress_comment], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 200,
+        title: "fix: crash".to_string(),
+        draft: false,
+        body: Some("This is a hotfix for production.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    assert!(
+        !provider.removed_labels().contains(&"hotfix".to_string()),
+        "remove_label must NOT be called for hotfix when it is not currently applied; \
+         removed: {:?}",
         provider.removed_labels()
     );
 }
 
 #[test]
-async fn test_suppression_multi_label() {
-    let body = "@merge-warden suppress: hotfix\n@merge-warden suppress: tech-debt";
-    let suppress_comment = make_comment(1, "alice", body);
+async fn test_suppression_isolated_to_named_label_only() {
+    // Suppressing "breaking-change" must not affect "security" detection or application.
+    let suppress_comment = make_comment(1, "alice", "@merge-warden suppress: breaking-change");
     let provider = KeywordLabelMockProvider::new(vec![suppress_comment], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 201,
+        title: "feat!: remove endpoint".to_string(),
+        draft: false,
+        body: Some("security: this addresses a vulnerability".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    // breaking-change is suppressed → must not appear
+    assert!(
+        !labels.contains(&"breaking-change".to_string()),
+        "breaking-change must be suppressed; got: {:?}",
+        labels
+    );
+    // security is NOT suppressed → must appear
+    assert!(
+        labels.contains(&"security".to_string()),
+        "security must still be applied even when breaking-change is suppressed; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+async fn test_suppression_multi_label_different_suppressors() {
+    // Two labels suppressed by two different commenters
+    let comments = vec![
+        make_comment(1, "alice", "@merge-warden suppress: hotfix"),
+        make_comment(2, "bob", "@merge-warden suppress: tech-debt"),
+    ];
+    let provider = KeywordLabelMockProvider::new(comments, vec![]);
     let config = CurrentPullRequestValidationConfiguration {
         bot_mention: "@merge-warden".to_string(),
         ..Default::default()
@@ -4066,18 +4773,22 @@ async fn test_suppression_multi_label() {
         .unwrap();
     assert!(
         !labels.contains(&"hotfix".to_string()),
-        "suppressed hotfix must not be applied; got: {:?}",
+        "hotfix suppressed; got: {:?}",
         labels
     );
     assert!(
         !labels.contains(&"tech-debt".to_string()),
-        "suppressed tech-debt must not be applied; got: {:?}",
+        "tech-debt suppressed; got: {:?}",
         labels
     );
+    assert!(!provider.added_labels().contains(&"hotfix".to_string()));
+    assert!(!provider.added_labels().contains(&"tech-debt".to_string()));
 }
 
 #[test]
-async fn test_suppression_list_comments_failure_falls_back_gracefully() {
+async fn test_suppression_list_comments_failure_falls_back_to_no_suppression() {
+    // When list_comments fails, the function must behave as if no suppression is in effect
+    // and still apply the label. A warn! is logged but no error is returned.
     let provider = KeywordLabelMockProvider::new(vec![], vec![]).with_failing_list_comments();
     let config = CurrentPullRequestValidationConfiguration {
         bot_mention: "@merge-warden".to_string(),
@@ -4094,20 +4805,28 @@ async fn test_suppression_list_comments_failure_falls_back_gracefully() {
         }),
         milestone_number: None,
     };
-    let labels = set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
-        .await
-        .unwrap();
+    // Must succeed (no propagated error)
+    let result = set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config)).await;
+    assert!(
+        result.is_ok(),
+        "must return Ok even when list_comments fails"
+    );
+    let labels = result.unwrap();
     assert!(
         labels.contains(&"hotfix".to_string()),
-        "when list_comments fails, label must still be applied; got: {:?}",
+        "when list_comments fails, hotfix must still be applied; got: {:?}",
         labels
+    );
+    assert!(
+        provider.added_labels().contains(&"hotfix".to_string()),
+        "add_labels must be called with hotfix when fallback to no-suppression"
     );
 }
 
-// ── Explanation comment lifecycle tests ──────────────────────────────────────
+// ── Explanation comment lifecycle tests ───────────────────────────────────────
 
 #[test]
-async fn test_explanation_comment_posted_when_label_triggered() {
+async fn test_explanation_comment_posted_when_label_triggered_and_no_prior_comment() {
     let provider = KeywordLabelMockProvider::new(vec![], vec![]);
     let config = CurrentPullRequestValidationConfiguration {
         bot_mention: "@merge-warden".to_string(),
@@ -4131,13 +4850,26 @@ async fn test_explanation_comment_posted_when_label_triggered() {
     let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
     assert!(
         posted.iter().any(|c| c.contains(&hotfix_marker)),
-        "an explanation comment for 'hotfix' must be posted; posted: {:?}",
+        "explanation comment for 'hotfix' must be posted when label is triggered; posted: {:?}",
         posted
+    );
+    // Comment must contain the full expected body (marker on first line)
+    let expected_body = super::build_keyword_label_comment("hotfix", "@merge-warden");
+    assert!(
+        posted.iter().any(|c| *c == expected_body),
+        "posted comment must match the expected body exactly; posted: {:?}",
+        posted
+    );
+    // No deletion must have occurred (no prior comment)
+    assert!(
+        provider.deleted_comment_ids().is_empty(),
+        "no comment must be deleted when there was no prior explanation comment"
     );
 }
 
 #[test]
-async fn test_explanation_comment_idempotent_when_identical_exists() {
+async fn test_explanation_comment_idempotent_when_identical_body_exists() {
+    // If the existing comment already has the exact expected body, no API call should be made.
     let expected_body = super::build_keyword_label_comment("hotfix", "@merge-warden");
     let existing = make_comment(99, "merge-warden[bot]", &expected_body);
     let provider = KeywordLabelMockProvider::new(vec![existing], vec![]);
@@ -4161,31 +4893,124 @@ async fn test_explanation_comment_idempotent_when_identical_exists() {
         .unwrap();
     assert!(
         provider.posted_comments().is_empty(),
-        "identical existing comment must not trigger re-post; posted: {:?}",
+        "must NOT post a new comment when the existing one is identical; posted: {:?}",
         provider.posted_comments()
     );
     assert!(
         provider.deleted_comment_ids().is_empty(),
-        "identical existing comment must not be deleted; deleted: {:?}",
+        "must NOT delete the existing identical comment; deleted: {:?}",
         provider.deleted_comment_ids()
     );
 }
 
 #[test]
-async fn test_explanation_comment_deleted_when_detection_clears() {
+async fn test_explanation_comment_stale_body_replaced_with_fresh_one() {
+    // If an existing comment has the marker but a DIFFERENT body (e.g., format changed),
+    // the stale comment must be deleted and a new one posted.
     let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
-    let stale = make_comment(50, "bot", &format!("{} stale body", hotfix_marker));
+    // Deliberately use a body that contains the marker but differs from the current format
+    let stale_body = format!(
+        "{} OUTDATED FORMAT - hotfix label was applied",
+        hotfix_marker
+    );
+    let stale = make_comment(77, "merge-warden[bot]", &stale_body);
     let provider = KeywordLabelMockProvider::new(vec![stale], vec![]);
     let config = CurrentPullRequestValidationConfiguration {
         bot_mention: "@merge-warden".to_string(),
         ..Default::default()
     };
-    // PR body no longer mentions hotfix -> detection does not fire
+    let pr = PullRequest {
+        number: 50,
+        title: "fix: crash".to_string(),
+        draft: false,
+        body: Some("This is a hotfix for the server crash.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    assert!(
+        provider.deleted_comment_ids().contains(&77),
+        "stale explanation comment with outdated body must be deleted; deleted: {:?}",
+        provider.deleted_comment_ids()
+    );
+    let expected_body = super::build_keyword_label_comment("hotfix", "@merge-warden");
+    assert!(
+        provider
+            .posted_comments()
+            .iter()
+            .any(|c| *c == expected_body),
+        "a fresh explanation comment must be posted after deleting the stale one; posted: {:?}",
+        provider.posted_comments()
+    );
+}
+
+#[test]
+async fn test_explanation_comment_two_stale_copies_both_deleted_before_repost() {
+    // Two identical stale copies must both be deleted before one fresh comment is posted.
+    let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    let stale_body = format!("{} old format v1", hotfix_marker);
+    let stale1 = make_comment(80, "bot", &stale_body);
+    let stale2 = make_comment(81, "bot", &stale_body);
+    let provider = KeywordLabelMockProvider::new(vec![stale1, stale2], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 51,
+        title: "fix: crash".to_string(),
+        draft: false,
+        body: Some("This is a hotfix for the server crash.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    let deleted = provider.deleted_comment_ids();
+    assert!(
+        deleted.contains(&80),
+        "first stale copy must be deleted; deleted: {:?}",
+        deleted
+    );
+    assert!(
+        deleted.contains(&81),
+        "second stale copy must be deleted; deleted: {:?}",
+        deleted
+    );
+    assert_eq!(
+        provider.posted_comments().len(),
+        1,
+        "exactly one fresh comment must be posted; posted: {:?}",
+        provider.posted_comments()
+    );
+}
+
+#[test]
+async fn test_explanation_comment_deleted_when_detection_clears() {
+    // When the PR is edited and the keyword no longer triggers,
+    // the stale explanation comment must be deleted.
+    let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    let stale = make_comment(50, "bot", &format!("{} hotfix was here", hotfix_marker));
+    let provider = KeywordLabelMockProvider::new(vec![stale], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    // PR body no longer mentions hotfix
     let pr = PullRequest {
         number: 32,
-        title: "fix: unrelated".to_string(),
+        title: "fix: unrelated cleanup".to_string(),
         draft: false,
-        body: Some("This PR fixes an unrelated issue.".to_string()),
+        body: Some("This PR fixes an unrelated formatting issue.".to_string()),
         author: Some(User {
             id: 1,
             login: "dev".to_string(),
@@ -4197,13 +5022,22 @@ async fn test_explanation_comment_deleted_when_detection_clears() {
         .unwrap();
     assert!(
         provider.deleted_comment_ids().contains(&50),
-        "stale explanation comment must be deleted when detection clears; deleted: {:?}",
+        "stale explanation comment must be deleted when hotfix detection clears; deleted: {:?}",
         provider.deleted_comment_ids()
+    );
+    // No new comment must be posted (hotfix not triggered)
+    assert!(
+        !provider
+            .posted_comments()
+            .iter()
+            .any(|c| c.contains(&hotfix_marker)),
+        "no new hotfix explanation comment must be posted when hotfix is not triggered"
     );
 }
 
 #[test]
 async fn test_explanation_comment_deleted_when_label_suppressed() {
+    // When a label is suppressed, any existing explanation comment for it must also be deleted.
     let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
     let explanation = make_comment(60, "bot", &format!("{} hotfix explanation", hotfix_marker));
     let suppress = make_comment(61, "alice", "@merge-warden suppress: hotfix");
@@ -4229,6 +5063,154 @@ async fn test_explanation_comment_deleted_when_label_suppressed() {
     assert!(
         provider.deleted_comment_ids().contains(&60),
         "explanation comment must be deleted when label is suppressed; deleted: {:?}",
+        provider.deleted_comment_ids()
+    );
+    // And it must not be re-posted
+    assert!(
+        !provider
+            .posted_comments()
+            .iter()
+            .any(|c| c.contains(&hotfix_marker)),
+        "deleted explanation comment must not be re-posted for suppressed label"
+    );
+}
+
+#[test]
+async fn test_explanation_comments_independent_per_label() {
+    // Triggering hotfix must only post a hotfix comment.
+    // Security is not triggered, so no security comment must be posted or deleted.
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 60,
+        title: "fix: crash".to_string(),
+        draft: false,
+        // Only hotfix keyword; no security/vulnerability keyword
+        body: Some("This is a hotfix for the production outage.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    let posted = provider.posted_comments();
+    let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    let security_marker = format!("{}security -->", KEYWORD_LABEL_COMMENT_MARKER);
+    // Hotfix comment MUST be posted
+    assert!(
+        posted.iter().any(|c| c.contains(&hotfix_marker)),
+        "hotfix explanation comment must be posted when hotfix triggered; posted: {:?}",
+        posted
+    );
+    // Security comment must NOT be posted (security was not triggered)
+    assert!(
+        !posted.iter().any(|c| c.contains(&security_marker)),
+        "security explanation comment must NOT be posted when security not triggered; posted: {:?}",
+        posted
+    );
+    // No deletion must happen when there are no stale comments
+    assert!(
+        provider.deleted_comment_ids().is_empty(),
+        "no comments must be deleted when starting with empty comment list"
+    );
+}
+
+#[test]
+async fn test_clearing_one_label_does_not_affect_other_labels_comment() {
+    // Hotfix detection fires → hotfix comment posted/managed
+    // Security no longer triggers → stale security comment must be deleted
+    // Each label's comment lifecycle is managed independently.
+    let security_marker = format!("{}security -->", KEYWORD_LABEL_COMMENT_MARKER);
+    let stale_security = make_comment(
+        10,
+        "bot",
+        &format!("{} old security comment", security_marker),
+    );
+    let provider = KeywordLabelMockProvider::new(vec![stale_security], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    // Security was previously triggered but the PR body was updated to remove it.
+    // Hotfix is now triggered.
+    let pr = PullRequest {
+        number: 61,
+        title: "fix: crash".to_string(),
+        draft: false,
+        body: Some("This is a hotfix for production.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    // Stale security comment must be deleted
+    assert!(
+        provider.deleted_comment_ids().contains(&10),
+        "stale security comment must be deleted when security detection clears; deleted: {:?}",
+        provider.deleted_comment_ids()
+    );
+    // Hotfix comment must be posted
+    let hotfix_marker = format!("{}hotfix -->", KEYWORD_LABEL_COMMENT_MARKER);
+    assert!(
+        provider
+            .posted_comments()
+            .iter()
+            .any(|c| c.contains(&hotfix_marker)),
+        "hotfix explanation comment must be posted; posted: {:?}",
+        provider.posted_comments()
+    );
+    // Security comment must NOT be re-posted (security not triggered)
+    assert!(
+        !provider
+            .posted_comments()
+            .iter()
+            .any(|c| c.contains(&security_marker)),
+        "security explanation comment must NOT be re-posted; posted: {:?}",
+        provider.posted_comments()
+    );
+}
+
+#[test]
+async fn test_no_unnecessary_api_calls_when_no_keyword_matched() {
+    // PR with no keyword content (no breaking change / security / hotfix / tech debt):
+    // explanation comment management must make zero add_comment / delete_comment calls.
+    let provider = KeywordLabelMockProvider::new(vec![], vec![]);
+    let config = CurrentPullRequestValidationConfiguration {
+        bot_mention: "@merge-warden".to_string(),
+        ..Default::default()
+    };
+    let pr = PullRequest {
+        number: 70,
+        title: "docs: update readme".to_string(),
+        draft: false,
+        body: Some("Updated the README with installation instructions.".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "dev".to_string(),
+        }),
+        milestone_number: None,
+    };
+    set_pull_request_labels_with_config(&provider, "o", "r", &pr, Some(&config))
+        .await
+        .unwrap();
+    assert!(
+        provider.posted_comments().is_empty(),
+        "no explanation comments must be posted when no keywords triggered; posted: {:?}",
+        provider.posted_comments()
+    );
+    assert!(
+        provider.deleted_comment_ids().is_empty(),
+        "no comments must be deleted when no stale comments exist; deleted: {:?}",
         provider.deleted_comment_ids()
     );
 }

--- a/crates/server/src/webhook.rs
+++ b/crates/server/src/webhook.rs
@@ -266,6 +266,7 @@ impl MergeWardenWebhookHandler {
                     // is disabled by default. Configure it in .github/merge-warden.toml
                     // under [policies.pullRequests.issuePropagation] to enable it.
                     issue_propagation: Default::default(),
+                    bot_mention: self.policies.bot_mention.clone(),
                 }
             }
         };

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -5,3 +5,14 @@ Purpose: prevent reinventing utilities, modules, patterns, and "hidden" features
 Add to this whenever a reusable component becomes "the standard way".
 
 ## Crate Structure
+
+## `merge_warden_core` — labels
+
+| Name | Kind | Location | Description | Tags |
+|------|------|----------|-------------|------|
+| `is_keyword_negated` | fn | `merge_warden_core::labels` | Returns true when a negation word in the 5-word clause-scoped window before a regex match span indicates the keyword is negated | negation, keyword, detection |
+| `parse_suppressed_labels` | fn | `merge_warden_core::labels` | Scans PR comments for `<bot_mention> suppress: <label>` commands; returns HashMap of label→commenter login; skips bot's own explanation comments | suppression, labels, comments |
+| `build_keyword_label_comment` | fn | `merge_warden_core::labels` | Builds a per-label HTML-marker explanation comment body with human-readable text and copy-pasteable suppress command | comments, keyword, labels |
+| `KEYWORD_LABEL_COMMENT_MARKER` | const | `merge_warden_core::config` | HTML comment prefix `"<!-- MERGE_WARDEN_KEYWORD_LABEL:"` used as a unique per-label marker for idempotent comment management | marker, comments, labels |
+| `NEGATION_SINGLE_WORDS` | const | `merge_warden_core::labels` | Conservative list of single-word negation tokens used by `is_keyword_negated`; excludes ambiguous words like "eliminates" | negation, constants |
+| `set_pull_request_labels_with_config` | fn | `merge_warden_core::labels` | Applies change-type + keyword labels to a PR; supports negation-aware detection, comment-based suppression, explanation comment lifecycle, and smart label detection via `LabelManager` | labels, detection, negation, suppression |

--- a/docs/spec/design/labeling-system.md
+++ b/docs/spec/design/labeling-system.md
@@ -817,3 +817,150 @@ State labels are orthogonal to all other label categories:
 - [Validation Engine](./validation-engine.md) - How labeling integrates with validation rules
 - [Configuration System](./configuration-system.md) - Labeling configuration management
 - [Platform Integrations](../architecture/platform-integrations.md) - GitHub API integration patterns
+
+## Keyword Labels
+
+### Overview
+
+Several labels are applied when keyword phrases appear in the PR title or body. Because
+natural language frequently negates these phrases ("no breaking change", "doesn't introduce
+any security concerns"), the detection logic is negation-aware: a keyword match is only acted
+upon when it is **not** preceded by a negation word within the same clause.
+
+Keyword detection runs as part of every `set_pull_request_labels_with_config` invocation.
+
+### Detected Keywords and Labels
+
+| Keyword pattern (regex) | Label applied | Negation-aware? |
+| :--- | :--- | :--- |
+| `\bbreaking[\s\-]+change\b` | configured `breaking_change` label | Yes (body); No (title `!:` path) |
+| `\b(security\|vulnerability)\b` | configured `security` label | Yes |
+| `\bhotfix\b` | configured `hotfix` label | Yes |
+| `\btech(?:nical)?[\s\-]+debt\b` | configured `tech_debt` label | Yes |
+
+The `!:` (exclamation-colon) conventional commit footer is a deliberate breaking-change
+signal and is exempted from negation checking — it always triggers the breaking-change label
+regardless of body text.
+
+### Negation Detection
+
+**Algorithm:** `is_keyword_negated(text: &str, keyword_span: Range<usize>) -> bool`
+
+1. Extract the substring of `text` that precedes the keyword span.
+2. Find the rightmost clause boundary (`.`, `!`, `?`, `;`, `\n`) in that prefix.
+   `!` followed immediately by `[` (a Markdown image link) is **not** treated as a boundary.
+3. Tokenise the clause before the keyword using whitespace splits.
+4. Take the last 5 tokens (the look-back window).
+5. For each token, strip leading/trailing punctuation while preserving `'` and `-`
+   (so `"no,"`, `"(no)"`, and `"no:"` all normalise to `"no"`).
+6. Return `true` if any stripped token matches an entry in `NEGATION_SINGLE_WORDS`.
+
+**Negation word list (`NEGATION_SINGLE_WORDS`):**
+
+```
+no, not, never, without,
+don't, dont, doesn't, doesnt, isn't, isnt, aren't, arent, won't, wont
+```
+
+"cannot", "neither", and "nor" are **deliberately excluded**: "cannot" is ambiguous
+("we cannot wait to add a breaking change" is affirmative), and "neither"/"nor" require
+correlative context that a window-based approach cannot reliably evaluate. These may be
+added in a future improvement.
+
+**Clause boundary rationale:** Limiting look-back to the current clause prevents a negation
+in one sentence from suppressing a keyword in the next sentence. For example:
+> "No changes were needed. This introduced a breaking change."
+The "No" before the period does not affect the detection of "breaking change" in the
+following sentence.
+
+### Comment-Based Label Suppression
+
+Users can permanently suppress a keyword-triggered label by posting a PR comment containing
+the following command on its own line:
+
+```
+@merge-warden suppress: <label-name>
+```
+
+The bot mentions prefix is case-insensitive. Unknown commands are silently ignored.
+
+**Parser:** `parse_suppressed_labels(comments: &[Comment], bot_mention: &str) -> HashMap<String, String>`
+
+Returns a map of `label_name → first_commenter_login`. First-commenter-wins: if two users
+suppress the same label, only the first is recorded. Suppression entries are label-scoped —
+suppressing `breaking-change` does not affect any other label.
+
+The bot's own explanation comments (identified by `KEYWORD_LABEL_COMMENT_MARKER`) are
+excluded from suppression parsing, preventing the sample suppress command embedded in those
+comments from being treated as a real command.
+
+**Effect:**
+
+- If a label would be applied **and** is suppressed: it is not applied; any existing
+  instance of that label is removed from the PR.
+- If a label would not be applied: suppression has no effect.
+
+### Explanation Comments
+
+When a keyword label is applied, the bot posts a per-label explanation comment so the PR
+author knows why the label appeared and how to opt out.
+
+**Comment format:** `build_keyword_label_comment(label_name: &str, bot_mention: &str) -> String`
+
+The comment body begins with a unique HTML marker:
+
+```
+<!-- MERGE_WARDEN_KEYWORD_LABEL:<label-name> -->
+```
+
+The marker is used to locate and manage the comment idempotently across PR re-evaluations.
+
+**Lifecycle (managed per-label on every evaluation):**
+
+| Condition | Action |
+| :--- | :--- |
+| Label triggered; no prior comment | Post new comment |
+| Label triggered; existing comment body identical | No action (idempotent) |
+| Label triggered; existing comment body differs | Post fresh comment, then delete stale copies |
+| Label not triggered (or suppressed) | Delete all comments with this label's marker |
+
+The lifecycle uses a **post-first-then-delete** approach when replacing stale comments: the
+fresh comment is posted before stale copies are removed. This ensures an explanation comment
+is never permanently lost due to a transient API failure during deletion.
+
+API failures when posting or deleting explanation comments are logged at `warn!` and do not
+propagate — they do not fail the overall label management step.
+
+### `bot_mention` Configuration
+
+The bot mention prefix used in suppress commands defaults to `"@merge-warden"`. It is
+configurable at the application level via `ApplicationDefaults.bot_mention` in
+`app-config.toml`:
+
+```toml
+bot_mention = "@merge-warden"
+```
+
+**Repository-level override:** The `bot_mention` field is intentionally not configurable per
+repository (it is `#[serde(skip)]` in `RepositoryProvidedConfig`). In a single-tenant
+deployment this is never needed; in multi-tenant deployments all repositories share the same
+bot identity. If per-repository override is required in the future, the `#[serde(skip)]`
+annotation must be replaced with an optional merge that falls back to the application default.
+
+### Behavioural Assertions
+
+1. A keyword match preceded by a negation word within a 5-token, single-clause window does
+   not trigger the corresponding label.
+2. Punctuation attached to a negation token (`"no,"`, `"(no)"`, `"no:"`) is stripped before
+   comparison — these all count as the word `"no"`.
+3. A negation word in a prior clause (before `.`, `!`, `?`, `;`, or `\n`) does not
+   suppress a keyword in the current clause.
+4. `!` immediately followed by `[` (Markdown image link) is not treated as a clause boundary.
+5. A user-posted `<bot_mention> suppress: <label>` comment prevents the label from being
+   applied (or removes it if already present); the explanation comment is also deleted.
+6. The bot's own explanation comment sample text does not self-suppress the label.
+7. Explanation comments are idempotent: re-running on an unchanged PR posts no duplicate.
+8. Clearing a keyword from the PR title/body causes the explanation comment to be deleted
+   on the next evaluation.
+9. Each keyword label's comment lifecycle is independent of the others.
+10. API failures in comment posting/deletion are non-fatal and do not affect label application.

--- a/samples/app-config.sample.toml
+++ b/samples/app-config.sample.toml
@@ -16,6 +16,11 @@ enable_title_validation = true
 # default_title_pattern = "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9_-]+\\))?!?: .+"
 default_invalid_title_label = "pr-issue: invalid-title-format"
 
+# The mention string that users write in PR comments to issue bot commands.
+# Default: "@merge-warden". Change this if you have deployed the bot under a
+# different GitHub App name (e.g. "@acme-merge-warden").
+# bot_mention = "@merge-warden"
+
 # Require a work-item reference in the pull request description by default.
 enable_work_item_validation = true
 # default_work_item_pattern = "(?i)(fixes|closes|resolves|references|relates to)\\s+(#\\d+|GH-\\d+|https://github\\.com/[^/]+/[^/]+/issues/\\d+|[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+#\\d+)"


### PR DESCRIPTION
Replaces naive substring keyword detection with negation-aware matching, adds bot-comment-driven label suppression, and introduces per-label explanation comments with an idempotent lifecycle.

closes #250

## What Changed

- **Negation-aware keyword detection** (`is_keyword_negated`): a 5-word, clause-scoped look-back window prevents phrases like "no breaking change" or "doesn't introduce any security concern" from triggering labels. Clause boundaries (`.`, `!`, `?`, `;`, newline) constrain negation scope to the same sentence as the keyword.
- **Label suppression via bot comment** (`parse_suppressed_labels`): users can post `@merge-warden suppress: <label>` in a PR comment to permanently suppress a keyword-triggered label. The bot's own explanation comments are excluded from suppression parsing to prevent self-suppression from sample text.
- **Explanation comments** (`build_keyword_label_comment`): when a keyword label is applied, the bot posts a per-label HTML-marker comment explaining why the label was added and providing the exact suppress command. The comment lifecycle is idempotent (no re-post if body is unchanged), replaces stale copies on edit, and deletes the comment when detection clears or the label is suppressed.
- **`bot_mention` configuration**: threaded from `ApplicationDefaults` through `RepositoryProvidedConfig` and `CurrentPullRequestValidationConfiguration`, with a serde default of `"@merge-warden"`. Added commented entry to `samples/app-config.sample.toml`.
- **`KEYWORD_LABEL_COMMENT_MARKER` constant** added to `config.rs`, following the `WIP_COMMENT_MARKER` / `TITLE_COMMENT_MARKER` pattern.
- Replaced all four `body_lower.contains(...)` keyword checks with `lazy_static` word-boundary regexes + `is_keyword_negated` per match span.

## Why

Keyword detection previously matched "no breaking change" and "without security impact" as positives, generating false-positive labels. Users had no mechanism to override an incorrectly applied keyword label without removing it manually each time.

## How

`is_keyword_negated(text, keyword_span)` extracts the clause containing the keyword span, tokenises the preceding words, and returns `true` if any token from a fixed negation word-list (`no`, `not`, `never`, `without`, `don't`, `doesn't`, `isn't`, `aren't`, `won't`, and un-apostrophised variants) appears within the 5-token window immediately before the keyword.

`parse_suppressed_labels` scans `&[Comment]` line-by-line for lines prefixed with `bot_mention` (case-insensitive) followed by `suppress: <label>`. The result is a `HashMap<String, String>` mapping label name to the first commenter's login.

The explanation comment lifecycle mirrors `communicate_pr_title_validity_status`: API failures are logged at `warn!` and do not propagate.

## Testing Evidence

- **Test Coverage:** 1 956 lines of new/modified test code across `labels_tests.rs`. 480 unit tests total (up from 162 before this feature). Coverage includes:
  - 31 `is_keyword_negated` unit tests (each negation word, window boundary at 5 vs 6 tokens, clause boundary, substring traps such as "annotated" and "notable", all four keyword label types)
  - 12 `parse_suppressed_labels` unit tests (single command, two in one body, cross-comment, unknown command ignored, non-mention line ignored, case-insensitive match, custom bot_mention, first-commenter-wins, empty label ignored, self-suppression guard)
  - 6 `build_keyword_label_comment` unit tests (marker uniqueness per label, suppress command embedding, custom bot_mention, parseable by `parse_suppressed_labels`)
  - Integration tests for negation (all four keyword labels, affirmative variants, title vs body, `!:` override)
  - Integration tests for suppression (skip-apply, remove-existing, multi-label, `list_comments` failure graceful fallback)
  - Integration tests for explanation comment lifecycle (first post, idempotent, stale replace, delete on clear, delete on suppress, four labels independent)
- **Test Results:** 480 unit tests + 58 doc tests passing; 0 clippy warnings
- **Manual Testing:** None beyond the automated suite

## Reviewer Guidance

- **`is_keyword_negated` look-back window**: the choice of 5 tokens and clause-boundary characters is conservative; review whether edge cases in real PR descriptions warrant adjustment.
- **`parse_suppressed_labels` precedence**: only the first commenter's suppress command is recorded per label — verify this is the desired conflict-resolution policy.
- **Explanation comment self-suppression guard**: comments containing `KEYWORD_LABEL_COMMENT_MARKER` are skipped during suppression parsing. Review that the marker string is distinctive enough to avoid false skips.
- **No breaking changes** to existing public API surface; `SmartMockGitProvider` previously-unimplemented methods now return `Ok(())`, which may affect any test relying on panic behaviour from those methods.
- The `!:` (breaking change force-trigger via conventional commit footer) path is explicitly left negation-unaware by design.