### PR TITLE
feat(developer_platforms): add CommitStatus model

### DIFF
--- a/crates/developer_platforms/src/models.rs
+++ b/crates/developer_platforms/src/models.rs
@@ -461,6 +461,44 @@ pub struct User {
     pub login: String,
 }
 
+/// A single commit status entry returned by the GitHub Commit Statuses API.
+///
+/// GitHub returns commit statuses newest-first. When multiple entries exist for
+/// the same context, callers should use the first occurrence (i.e. the newest).
+/// Callers are responsible for deduplication by context; this struct represents
+/// a single raw entry as returned by the API without any deduplication applied.
+///
+/// Mapped from `GET /repos/{owner}/{repo}/commits/{sha}/statuses`.
+///
+/// # Examples
+///
+/// ```
+/// use merge_warden_developer_platforms::models::CommitStatus;
+///
+/// let status = CommitStatus {
+///     context: "renovate/stability-days".to_string(),
+///     state: "pending".to_string(),
+///     description: Some("Waiting for stability period".to_string()),
+/// };
+/// assert_eq!(status.context, "renovate/stability-days");
+/// assert_eq!(status.state, "pending");
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitStatus {
+    /// The context string that identifies which check produced this status.
+    ///
+    /// Example: `"renovate/stability-days"`.
+    pub context: String,
+
+    /// The state of the status.
+    ///
+    /// GitHub-defined values: `"pending"`, `"success"`, `"failure"`, `"error"`.
+    pub state: String,
+
+    /// Optional human-readable description of the status.
+    pub description: Option<String>,
+}
+
 /// Repository metadata used to evaluate conditional org policy conditions.
 ///
 /// Populated by [`merge_warden_developer_platforms::RepositoryMetadataProvider::get_repository_context`]

--- a/crates/developer_platforms/src/models_tests.rs
+++ b/crates/developer_platforms/src/models_tests.rs
@@ -876,3 +876,121 @@ fn test_issue_project_zero_number_allowed() {
     };
     assert_eq!(project.number, 0);
 }
+
+// ── CommitStatus tests ───────────────────────────────────────────────────────
+
+#[test]
+fn test_commit_status_round_trip_all_fields() {
+    // Serialize a CommitStatus with all three fields populated and deserialize
+    // it back; every field must survive the round-trip unchanged.
+    let status = CommitStatus {
+        context: "renovate/stability-days".to_string(),
+        state: "pending".to_string(),
+        description: Some("Waiting for stability period".to_string()),
+    };
+
+    let json_str = to_string(&status).expect("Failed to serialize CommitStatus");
+    let deserialized: CommitStatus =
+        from_str(&json_str).expect("Failed to deserialize CommitStatus");
+
+    assert_eq!(deserialized.context, "renovate/stability-days");
+    assert_eq!(deserialized.state, "pending");
+    assert_eq!(
+        deserialized.description,
+        Some("Waiting for stability period".to_string())
+    );
+}
+
+#[test]
+fn test_commit_status_round_trip_null_description() {
+    // Serialize a CommitStatus whose description is None (maps to JSON null)
+    // and verify the round-trip produces None again.
+    let status = CommitStatus {
+        context: "ci/build".to_string(),
+        state: "success".to_string(),
+        description: None,
+    };
+
+    let json_str = to_string(&status).expect("Failed to serialize CommitStatus");
+
+    // Confirm the JSON representation carries an explicit null for description
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json_str).expect("Failed to parse JSON");
+    assert!(parsed["description"].is_null());
+
+    let deserialized: CommitStatus =
+        from_str(&json_str).expect("Failed to deserialize CommitStatus");
+    assert_eq!(deserialized.context, "ci/build");
+    assert_eq!(deserialized.state, "success");
+    assert_eq!(deserialized.description, None);
+}
+
+#[test]
+fn test_commit_status_deserialize_from_github_payload() {
+    // Deserialize a JSON fragment that mirrors the shape returned by the
+    // GitHub Commit Statuses API (GET /repos/{owner}/{repo}/commits/{sha}/statuses).
+    let json_str = r#"{
+        "context": "renovate/stability-days",
+        "state": "failure",
+        "description": "Stability period not yet elapsed"
+    }"#;
+
+    let status: CommitStatus = from_str(json_str).expect("Failed to deserialize CommitStatus");
+
+    assert_eq!(status.context, "renovate/stability-days");
+    assert_eq!(status.state, "failure");
+    assert_eq!(
+        status.description,
+        Some("Stability period not yet elapsed".to_string())
+    );
+}
+
+#[test]
+fn test_commit_status_all_github_states_round_trip() {
+    // Verify each GitHub-defined state value (`pending`, `success`, `failure`,
+    // `error`) survives a serialization / deserialization cycle.
+    let states = ["pending", "success", "failure", "error"];
+
+    for state in states {
+        let status = CommitStatus {
+            context: "ci/check".to_string(),
+            state: state.to_string(),
+            description: None,
+        };
+
+        let json_str = to_string(&status).expect("Failed to serialize CommitStatus");
+        let deserialized: CommitStatus =
+            from_str(&json_str).expect("Failed to deserialize CommitStatus");
+
+        assert_eq!(deserialized.state, state);
+    }
+}
+
+#[test]
+fn test_commit_status_clone() {
+    // CommitStatus must implement Clone; cloned value must be independent.
+    let original = CommitStatus {
+        context: "renovate/stability-days".to_string(),
+        state: "pending".to_string(),
+        description: Some("desc".to_string()),
+    };
+
+    let cloned = original.clone();
+    assert_eq!(cloned.context, original.context);
+    assert_eq!(cloned.state, original.state);
+    assert_eq!(cloned.description, original.description);
+}
+
+#[test]
+fn test_commit_status_debug_contains_context() {
+    // CommitStatus must implement Debug; the debug output must contain the
+    // context string so log messages are useful.
+    let status = CommitStatus {
+        context: "renovate/stability-days".to_string(),
+        state: "pending".to_string(),
+        description: None,
+    };
+
+    let debug_output = format!("{:?}", status);
+    assert!(debug_output.contains("renovate/stability-days"));
+}


### PR DESCRIPTION
## Summary

- Adds `CommitStatus` struct to `crates/developer_platforms/src/models.rs` mapping the GitHub Commit Statuses API response (`GET /repos/{owner}/{repo}/commits/{sha}/statuses`)
- Adds 6 unit tests to `crates/developer_platforms/src/models_tests.rs` covering serde round-trips and edge cases
- Closes task 1.0 of the FR-008 Renovate Stability Label Management feature

## What changed

**`crates/developer_platforms/src/models.rs`**

New `pub struct CommitStatus` with:
- `#[derive(Debug, Clone, Serialize, Deserialize)]`
- `pub context: String` — identifies the check (e.g. `"renovate/stability-days"`)
- `pub state: String` — GitHub-defined values: `pending`, `success`, `failure`, `error`
- `pub description: Option<String>` — optional human-readable description
- Doc comment explaining newest-first ordering and caller deduplication responsibility

Accessible as `merge_warden_developer_platforms::models::CommitStatus` (via the existing `pub mod models` export in `lib.rs`).

**`crates/developer_platforms/src/models_tests.rs`**

Six new tests:
- `test_commit_status_round_trip_all_fields` — all three fields survive serde round-trip
- `test_commit_status_round_trip_null_description` — `description: None` serialises as JSON `null` and round-trips back to `None`
- `test_commit_status_deserialize_from_github_payload` — deserialises a GitHub API-shaped JSON fragment
- `test_commit_status_all_github_states_round_trip` — all four GitHub state values (`pending`, `success`, `failure`, `error`) survive round-trip
- `test_commit_status_clone` — `Clone` derive works correctly
- `test_commit_status_debug_contains_context` — `Debug` output contains the context string

## Test plan

- [x] `cargo test -p merge_warden_developer_platforms` — 153 tests pass, 0 failures
- [x] All acceptance criteria from task 1.0 verified: struct fields, derives, doc comment, serde round-trips, crate-root accessibility

## Audit summary

- Mutation testing: N/A (pure data model — no logic branches to mutate beyond Option serialisation, which is covered by the null-description round-trip test)
- Fuzz: N/A (no parsing logic; serde handles all decoding)
- Kani: N/A (no safety-critical invariants)
- Security: No findings — pure data model, no I/O, no secrets, no error surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)