### PR TITLE
feat(stability): add Renovate stability label management (FR008)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1959,7 +1959,9 @@ impl RenovateStabilityConfig {
     /// Merges `over` on top of `base` (lower-priority).
     ///
     /// Field-level rules:
-    /// - `enabled`: `base.enabled || over.enabled` — once enabled in either tier, stays enabled
+    /// - `enabled`: `base.enabled || over.enabled` — once enabled in either tier, stays enabled.
+    ///   This means a repo-level `enabled = false` cannot override an app-level `enabled = true`.
+    ///   To disable for all repos, set `enabled = false` at the application defaults level.
     /// - `pending_stability_label`: `over` wins if non-empty and differs from the default label;
     ///   otherwise `base` is used
     pub(crate) fn merge(base: &Self, over: &Self) -> Self {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -47,6 +47,12 @@ pub const WIP_COMMENT_MARKER: &str = "<!-- PR_WIP_CHECK -->";
 /// prefix is sufficient to locate any keyword-label explanation comment.
 pub const KEYWORD_LABEL_COMMENT_MARKER: &str = "<!-- MERGE_WARDEN_KEYWORD_LABEL:";
 
+/// Context string identifying the Renovate stability check in GitHub commit statuses.
+pub const RENOVATE_STABILITY_CHECK_CONTEXT: &str = "renovate/stability-days";
+
+/// Default label name applied while the Renovate stability period has not elapsed.
+pub const RENOVATE_STABILITY_LABEL: &str = "pr-validation: pending-stability";
+
 /// HTML comment marker used to identify configuration validity status comments.
 ///
 /// Merge Warden uses this marker to find and update (or delete) configuration
@@ -386,6 +392,10 @@ pub struct ApplicationDefaults {
     #[serde(default)]
     pub pr_state_labels: PrStateLabelsConfig,
 
+    /// Application-level defaults for Renovate stability label management
+    #[serde(default)]
+    pub renovate_stability: RenovateStabilityConfig,
+
     /// Bot mention prefix used for comment-based label suppression.
     ///
     /// PR participants post a comment line of the form `<bot_mention> suppress: <label-name>`
@@ -456,6 +466,7 @@ impl Default for ApplicationDefaults {
             change_type_labels: ChangeTypeLabelConfig::default(),
             wip_check: WipCheckConfig::default(),
             pr_state_labels: PrStateLabelsConfig::default(),
+            renovate_stability: RenovateStabilityConfig::default(),
             bot_mention: ApplicationDefaults::default_bot_mention(),
             org_policy_source: None,
         }
@@ -1137,6 +1148,9 @@ pub struct CurrentPullRequestValidationConfiguration {
     /// Configuration for state-based PR lifecycle labels
     pub pr_state_labels: PrStateLabelsConfig,
 
+    /// Configuration for Renovate stability-days label management.
+    pub renovate_stability: RenovateStabilityConfig,
+
     /// Rules for bypassing validation checks
     pub bypass_rules: BypassRules,
 
@@ -1170,6 +1184,7 @@ impl CurrentPullRequestValidationConfiguration {
             change_type_labels: Some(app.change_type_labels.clone()),
             wip_check: app.wip_check.clone(),
             pr_state_labels: app.pr_state_labels.clone(),
+            renovate_stability: app.renovate_stability.clone(),
             bypass_rules: app.bypass_rules.clone(),
             issue_propagation: IssuePropagationConfig::default(),
             bot_mention: app.bot_mention.clone(),
@@ -1207,6 +1222,7 @@ impl CurrentPullRequestValidationConfiguration {
             change_type_labels: None, // Use default behavior for tests
             wip_check: WipCheckConfig::default(),
             pr_state_labels: PrStateLabelsConfig::default(),
+            renovate_stability: RenovateStabilityConfig::default(),
             bypass_rules: bypass_rules.unwrap_or_default(),
             issue_propagation: IssuePropagationConfig::default(),
             bot_mention: "@merge-warden".to_string(),
@@ -1227,6 +1243,7 @@ impl Default for CurrentPullRequestValidationConfiguration {
             change_type_labels: None, // Default to None, will be populated from app defaults
             wip_check: WipCheckConfig::default(),
             pr_state_labels: PrStateLabelsConfig::default(),
+            renovate_stability: RenovateStabilityConfig::default(),
             bypass_rules: BypassRules::default(),
             issue_propagation: IssuePropagationConfig::default(),
             bot_mention: "@merge-warden".to_string(),
@@ -1277,6 +1294,10 @@ pub struct PullRequestsPoliciesConfig {
     /// Configuration for issue metadata propagation.
     #[serde(default, rename = "issuePropagation")]
     pub issue_propagation: IssuePropagationConfig,
+
+    /// Configuration for Renovate stability-days label management.
+    #[serde(default, rename = "renovateStability")]
+    pub renovate_stability: RenovateStabilityConfig,
 }
 
 /// Configuration for PR title policy
@@ -1450,6 +1471,7 @@ impl RepositoryProvidedConfig {
             change_type_labels: self.change_type_labels.clone(),
             wip_check,
             pr_state_labels,
+            renovate_stability: pr_policies.renovate_stability.clone(),
             // Merge per-sub-rule: if the repo specified a particular bypass rule,
             // use it; otherwise fall back to the server-level default for that rule.
             // This prevents a repo that overrides only one category from silently
@@ -1890,6 +1912,80 @@ impl Default for PrStateLabelsConfig {
     }
 }
 
+/// Configuration for Renovate stability-days label management.
+///
+/// When enabled, [`RENOVATE_STABILITY_LABEL`] (or the configured label name) is applied
+/// to the PR while the `renovate/stability-days` commit status is `pending`, `error`, or
+/// `failure`, and removed when the status is `success`.  The label is purely informational —
+/// it never influences the merge-blocking check conclusion.
+///
+/// # Examples
+///
+/// ```
+/// use merge_warden_core::config::{RenovateStabilityConfig, RENOVATE_STABILITY_LABEL};
+///
+/// let config = RenovateStabilityConfig::default();
+/// assert!(config.enabled);
+/// assert_eq!(config.pending_stability_label, RENOVATE_STABILITY_LABEL);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RenovateStabilityConfig {
+    /// Whether Renovate stability label management is enabled.
+    ///
+    /// Defaults to `true`.  The merge rule is `base || over`: once either tier enables
+    /// the feature the merged value is always `true`.  A repository can only opt in,
+    /// not opt out.
+    #[serde(default = "RenovateStabilityConfig::default_enabled")]
+    pub enabled: bool,
+
+    /// Label applied while the Renovate stability period has not yet elapsed.
+    ///
+    /// Defaults to [`RENOVATE_STABILITY_LABEL`].
+    #[serde(default = "RenovateStabilityConfig::default_label")]
+    pub pending_stability_label: String,
+}
+
+impl RenovateStabilityConfig {
+    /// Default value for `enabled` — opt-in enabled by default.
+    fn default_enabled() -> bool {
+        true
+    }
+
+    /// Default value for `pending_stability_label`.
+    fn default_label() -> String {
+        RENOVATE_STABILITY_LABEL.to_string()
+    }
+
+    /// Merges `over` on top of `base` (lower-priority).
+    ///
+    /// Field-level rules:
+    /// - `enabled`: `base.enabled || over.enabled` — once enabled in either tier, stays enabled
+    /// - `pending_stability_label`: `over` wins if non-empty and differs from the default label;
+    ///   otherwise `base` is used
+    pub(crate) fn merge(base: &Self, over: &Self) -> Self {
+        let label = if !over.pending_stability_label.is_empty()
+            && over.pending_stability_label != RENOVATE_STABILITY_LABEL
+        {
+            over.pending_stability_label.clone()
+        } else {
+            base.pending_stability_label.clone()
+        };
+        Self {
+            enabled: base.enabled || over.enabled,
+            pending_stability_label: label,
+        }
+    }
+}
+
+impl Default for RenovateStabilityConfig {
+    fn default() -> Self {
+        Self {
+            enabled: Self::default_enabled(),
+            pending_stability_label: Self::default_label(),
+        }
+    }
+}
+
 /// A resolved, merged set of validation policies ready for enforcement.
 ///
 /// `PolicySet` is the single value passed to the validation engine. It is
@@ -1921,6 +2017,8 @@ pub struct PolicySet {
     pub wip: WipCheckConfig,
     /// Lifecycle state labelling policy.
     pub pr_state: PrStateLabelsConfig,
+    /// Renovate stability-days label management policy.
+    pub renovate_stability: RenovateStabilityConfig,
     /// Issue-to-PR field propagation policy.
     pub issue_propagation: IssuePropagationConfig,
     /// Conventional-commit type → label mapping policy.
@@ -1950,6 +2048,10 @@ impl PolicySet {
             size: PrSizeCheckConfig::merge(&self.size, &over.size),
             wip: WipCheckConfig::merge(&self.wip, &over.wip),
             pr_state: PrStateLabelsConfig::merge(&self.pr_state, &over.pr_state),
+            renovate_stability: RenovateStabilityConfig::merge(
+                &self.renovate_stability,
+                &over.renovate_stability,
+            ),
             issue_propagation: IssuePropagationConfig::merge(
                 &self.issue_propagation,
                 &over.issue_propagation,
@@ -1985,6 +2087,7 @@ impl PolicySet {
             size: pr.size_policies.clone(),
             wip: pr.wip_policies.clone(),
             pr_state: pr.pr_state_policies.clone(),
+            renovate_stability: pr.renovate_stability.clone(),
             issue_propagation: pr.issue_propagation.clone(),
             change_type_labels: section.change_type_labels.clone().unwrap_or_default(),
             bypass_rules: BypassRules::default(),
@@ -2047,6 +2150,7 @@ impl PolicySet {
             change_type_labels: Some(self.change_type_labels.clone()),
             wip_check: self.wip.clone(),
             pr_state_labels: self.pr_state.clone(),
+            renovate_stability: self.renovate_stability.clone(),
             bypass_rules: self.bypass_rules.clone(),
             issue_propagation: self.issue_propagation.clone(),
             bot_mention: app_defaults.bot_mention.clone(),
@@ -2083,6 +2187,7 @@ impl PolicySet {
             size: app.pr_size_check.clone(),
             wip: app.wip_check.clone(),
             pr_state: app.pr_state_labels.clone(),
+            renovate_stability: app.renovate_stability.clone(),
             // `ApplicationDefaults` carries no issue-propagation settings — issue propagation
             // is a repository-level opt-in feature, so the app tier always contributes
             // `IssuePropagationConfig::default()` (both flags `false`).
@@ -2121,6 +2226,7 @@ impl PolicySet {
             size: pr.size_policies.clone(),
             wip: pr.wip_policies.clone(),
             pr_state: pr.pr_state_policies.clone(),
+            renovate_stability: pr.renovate_stability.clone(),
             issue_propagation: pr.issue_propagation.clone(),
             change_type_labels: repo.change_type_labels.clone().unwrap_or_default(),
             bypass_rules,

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -739,6 +739,7 @@ fn test_application_defaults_bypass_rules_serialization() {
         change_type_labels: ChangeTypeLabelConfig::default(),
         wip_check: WipCheckConfig::default(),
         pr_state_labels: crate::config::PrStateLabelsConfig::default(),
+        renovate_stability: crate::config::RenovateStabilityConfig::default(),
         bot_mention: "@merge-warden".to_string(),
         org_policy_source: None,
     };
@@ -6541,4 +6542,170 @@ async fn test_conditional_policy_toml_with_no_org_policy_source_ignores_conditio
         !result.enforce_title_convention,
         "No org_policy_source means no conditional policies regardless of metadata_provider"
     );
+}
+
+// ============================================================
+// RenovateStabilityConfig — FR-008 Task 5
+// ============================================================
+
+/// Spec assertion: RenovateStabilityConfig::default() → enabled=true.
+#[test]
+fn test_renovate_stability_config_default_enabled_is_true() {
+    let config = crate::config::RenovateStabilityConfig::default();
+    assert!(config.enabled, "RenovateStabilityConfig::default must have enabled=true");
+}
+
+/// Spec assertion: RenovateStabilityConfig::default() → label == RENOVATE_STABILITY_LABEL.
+#[test]
+fn test_renovate_stability_config_default_label_is_constant() {
+    let config = crate::config::RenovateStabilityConfig::default();
+    assert_eq!(
+        config.pending_stability_label,
+        crate::config::RENOVATE_STABILITY_LABEL,
+        "default label must equal RENOVATE_STABILITY_LABEL constant"
+    );
+}
+
+/// Spec assertion: RENOVATE_STABILITY_LABEL constant has the expected value.
+#[test]
+fn test_renovate_stability_label_constant_value() {
+    assert_eq!(
+        crate::config::RENOVATE_STABILITY_LABEL,
+        "pr-validation: pending-stability"
+    );
+}
+
+/// Spec assertion: RENOVATE_STABILITY_CHECK_CONTEXT constant has the expected value.
+#[test]
+fn test_renovate_stability_check_context_constant_value() {
+    assert_eq!(
+        crate::config::RENOVATE_STABILITY_CHECK_CONTEXT,
+        "renovate/stability-days"
+    );
+}
+
+/// Spec assertion (merge): repo enabled=false does NOT override app default enabled=true.
+/// Result: enabled = base || over = true || false = true.
+#[test]
+fn test_renovate_stability_config_merge_enabled_or_semantics_base_true_over_false() {
+    let base = crate::config::RenovateStabilityConfig {
+        enabled: true,
+        pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+    };
+    let over = crate::config::RenovateStabilityConfig {
+        enabled: false,
+        pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+    };
+    let merged = crate::config::RenovateStabilityConfig::merge(&base, &over);
+    assert!(
+        merged.enabled,
+        "enabled must use base || over, so true || false = true"
+    );
+}
+
+/// Spec assertion (merge): base false + over true → true.
+#[test]
+fn test_renovate_stability_config_merge_enabled_or_semantics_base_false_over_true() {
+    let base = crate::config::RenovateStabilityConfig {
+        enabled: false,
+        pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+    };
+    let over = crate::config::RenovateStabilityConfig {
+        enabled: true,
+        pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+    };
+    let merged = crate::config::RenovateStabilityConfig::merge(&base, &over);
+    assert!(merged.enabled, "base false || over true = true");
+}
+
+/// Spec assertion (merge): base false + over false → false.
+#[test]
+fn test_renovate_stability_config_merge_enabled_both_false_stays_false() {
+    let base = crate::config::RenovateStabilityConfig {
+        enabled: false,
+        pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+    };
+    let over = crate::config::RenovateStabilityConfig {
+        enabled: false,
+        pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+    };
+    let merged = crate::config::RenovateStabilityConfig::merge(&base, &over);
+    assert!(!merged.enabled, "false || false = false");
+}
+
+/// Spec assertion (merge): custom pending_stability_label in `over` wins.
+#[test]
+fn test_renovate_stability_config_merge_custom_label_wins() {
+    let base = crate::config::RenovateStabilityConfig {
+        enabled: true,
+        pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+    };
+    let over = crate::config::RenovateStabilityConfig {
+        enabled: true,
+        pending_stability_label: "custom-stability-label".to_string(),
+    };
+    let merged = crate::config::RenovateStabilityConfig::merge(&base, &over);
+    assert_eq!(
+        merged.pending_stability_label,
+        "custom-stability-label",
+        "non-default over label must win"
+    );
+}
+
+/// Spec assertion (merge): empty/default over label defers to base.
+#[test]
+fn test_renovate_stability_config_merge_default_over_label_defers_to_base() {
+    let base = crate::config::RenovateStabilityConfig {
+        enabled: true,
+        pending_stability_label: "base-custom-label".to_string(),
+    };
+    let over = crate::config::RenovateStabilityConfig {
+        enabled: true,
+        pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+    };
+    let merged = crate::config::RenovateStabilityConfig::merge(&base, &over);
+    assert_eq!(
+        merged.pending_stability_label,
+        "base-custom-label",
+        "when over has the default label, base custom label wins"
+    );
+}
+
+/// Spec assertion: ApplicationDefaults contains a renovate_stability field.
+#[test]
+fn test_application_defaults_contains_renovate_stability() {
+    let defaults = ApplicationDefaults::default();
+    // accessing the field compiles only if it exists
+    assert!(
+        defaults.renovate_stability.enabled,
+        "ApplicationDefaults.renovate_stability.enabled must default to true"
+    );
+}
+
+/// Spec assertion: CurrentPullRequestValidationConfiguration contains renovate_stability.
+#[test]
+fn test_current_pr_validation_config_contains_renovate_stability() {
+    let app = ApplicationDefaults::default();
+    let cfg = CurrentPullRequestValidationConfiguration::from_app_defaults(&app);
+    assert!(
+        cfg.renovate_stability.enabled,
+        "from_app_defaults must propagate renovate_stability.enabled"
+    );
+}
+
+/// Property-based: enabled is monotonically base || over across random booleans.
+proptest! {
+    #[test]
+    fn prop_renovate_stability_merge_enabled_is_or(base_en: bool, over_en: bool) {
+        let base = crate::config::RenovateStabilityConfig {
+            enabled: base_en,
+            pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+        };
+        let over = crate::config::RenovateStabilityConfig {
+            enabled: over_en,
+            pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+        };
+        let merged = crate::config::RenovateStabilityConfig::merge(&base, &over);
+        prop_assert_eq!(merged.enabled, base_en || over_en);
+    }
 }

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -6552,7 +6552,10 @@ async fn test_conditional_policy_toml_with_no_org_policy_source_ignores_conditio
 #[test]
 fn test_renovate_stability_config_default_enabled_is_true() {
     let config = crate::config::RenovateStabilityConfig::default();
-    assert!(config.enabled, "RenovateStabilityConfig::default must have enabled=true");
+    assert!(
+        config.enabled,
+        "RenovateStabilityConfig::default must have enabled=true"
+    );
 }
 
 /// Spec assertion: RenovateStabilityConfig::default() → label == RENOVATE_STABILITY_LABEL.
@@ -6646,8 +6649,7 @@ fn test_renovate_stability_config_merge_custom_label_wins() {
     };
     let merged = crate::config::RenovateStabilityConfig::merge(&base, &over);
     assert_eq!(
-        merged.pending_stability_label,
-        "custom-stability-label",
+        merged.pending_stability_label, "custom-stability-label",
         "non-default over label must win"
     );
 }
@@ -6665,8 +6667,7 @@ fn test_renovate_stability_config_merge_default_over_label_defers_to_base() {
     };
     let merged = crate::config::RenovateStabilityConfig::merge(&base, &over);
     assert_eq!(
-        merged.pending_stability_label,
-        "base-custom-label",
+        merged.pending_stability_label, "base-custom-label",
         "when over has the default label, base custom label wins"
     );
 }

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -2917,7 +2917,7 @@ pub async fn manage_renovate_stability_label<P: PullRequestProvider + Sync>(
             }
 
             provider
-                .add_labels(repo_owner, repo_name, pr_number, &[label_name.clone()])
+                .add_labels(repo_owner, repo_name, pr_number, std::slice::from_ref(&label_name))
                 .await
                 .map_err(|e| {
                     MergeWardenError::FailedToUpdatePullRequest(format!(

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -2942,36 +2942,24 @@ pub async fn manage_renovate_stability_label<P: PullRequestProvider + Sync>(
                 "Renovate stability period elapsed — removing label"
             );
 
-            match provider
+            // Providers are expected to treat a missing label (404) as Ok(()).
+            // Any remaining error is a genuine API failure.
+            provider
                 .remove_label(repo_owner, repo_name, pr_number, &label_name)
                 .await
-            {
-                Ok(()) => {
-                    info!(
-                        repository_owner = repo_owner,
-                        repository = repo_name,
-                        pr_number = pr_number,
-                        label = %label_name,
-                        "Removed Renovate stability label"
-                    );
-                }
-                Err(merge_warden_developer_platforms::errors::Error::InvalidResponse) => {
-                    // GitHub returns 404 when the label is not present on the PR.
-                    // Treat as a no-op — idempotent removal.
-                    debug!(
-                        repository_owner = repo_owner,
-                        repository = repo_name,
-                        pr_number = pr_number,
-                        label = %label_name,
-                        "Stability label already absent; skipping remove"
-                    );
-                }
-                Err(e) => {
-                    return Err(MergeWardenError::FailedToUpdatePullRequest(format!(
+                .map_err(|e| {
+                    MergeWardenError::FailedToUpdatePullRequest(format!(
                         "Failed to remove stability label: {e}"
-                    )));
-                }
-            }
+                    ))
+                })?;
+
+            info!(
+                repository_owner = repo_owner,
+                repository = repo_name,
+                pr_number = pr_number,
+                label = %label_name,
+                "Removed Renovate stability label"
+            );
         }
         state => {
             debug!(

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -11,7 +11,8 @@
 
 use crate::config::{
     ChangeTypeLabelConfig, CurrentPullRequestValidationConfiguration, KeywordLabelsConfig,
-    PrStateLabelsConfig, CONVENTIONAL_COMMIT_REGEX, KEYWORD_LABEL_COMMENT_MARKER,
+    PrStateLabelsConfig, RenovateStabilityConfig, CONVENTIONAL_COMMIT_REGEX,
+    KEYWORD_LABEL_COMMENT_MARKER, RENOVATE_STABILITY_CHECK_CONTEXT,
 };
 use crate::errors::MergeWardenError;
 use crate::size::{PrSizeCategory, PrSizeInfo};
@@ -2803,6 +2804,182 @@ pub async fn manage_pr_state_labels<P: PullRequestProvider>(
                 pr_number = pr_number,
                 label = %target,
                 "Applied PR state label"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Applies or removes the Renovate stability label based on the current HEAD commit status.
+///
+/// Fetches commit statuses for `head_sha`, filters by [`RENOVATE_STABILITY_CHECK_CONTEXT`],
+/// and applies or removes `config.pending_stability_label` accordingly.
+///
+/// This function is a no-op when:
+/// - `config.enabled` is `false`
+/// - no status entry for `renovate/stability-days` is present on `head_sha`
+///
+/// Label operations are idempotent: adding a label that is already present and
+/// removing a label that is absent are both safe and do not return errors.
+///
+/// # Arguments
+///
+/// * `provider`    - The Git provider implementation
+/// * `repo_owner`  - Repository owner
+/// * `repo_name`   - Repository name
+/// * `pr_number`   - Pull request number
+/// * `head_sha`    - HEAD commit SHA whose statuses are inspected
+/// * `config`      - Renovate stability label configuration
+pub async fn manage_renovate_stability_label<P: PullRequestProvider + Sync>(
+    provider: &P,
+    repo_owner: &str,
+    repo_name: &str,
+    pr_number: u64,
+    head_sha: &str,
+    config: &RenovateStabilityConfig,
+) -> Result<(), MergeWardenError> {
+    if !config.enabled {
+        debug!(
+            repository_owner = repo_owner,
+            repository = repo_name,
+            pr_number = pr_number,
+            "Renovate stability label management disabled — skipping"
+        );
+        return Ok(());
+    }
+
+    let statuses = provider
+        .get_commit_statuses(repo_owner, repo_name, head_sha)
+        .await
+        .map_err(|e| {
+            MergeWardenError::FailedToUpdatePullRequest(format!(
+                "Failed to fetch commit statuses: {e}"
+            ))
+        })?;
+
+    // Take the first (newest) entry for the renovate stability context.
+    let status = statuses
+        .iter()
+        .find(|s| s.context == RENOVATE_STABILITY_CHECK_CONTEXT);
+
+    let status = match status {
+        Some(s) => s,
+        None => {
+            debug!(
+                repository_owner = repo_owner,
+                repository = repo_name,
+                pr_number = pr_number,
+                "No renovate stability status found on HEAD commit — skipping"
+            );
+            return Ok(());
+        }
+    };
+
+    let label_name = config.pending_stability_label.clone();
+
+    match status.state.as_str() {
+        "pending" | "error" | "failure" => {
+            info!(
+                repository_owner = repo_owner,
+                repository = repo_name,
+                pr_number = pr_number,
+                state = %status.state,
+                label = %label_name,
+                "Renovate stability period active — applying label"
+            );
+
+            // Ensure the label exists in the repository before adding it to the PR.
+            let available = provider
+                .list_available_labels(repo_owner, repo_name)
+                .await
+                .map_err(|e| {
+                    MergeWardenError::FailedToUpdatePullRequest(format!(
+                        "Failed to list repository labels: {e}"
+                    ))
+                })?;
+
+            if !available.iter().any(|l| l.name == label_name) {
+                provider
+                    .create_label(
+                        repo_owner,
+                        repo_name,
+                        &label_name,
+                        "986ee2",
+                        Some("PR is waiting for Renovate stability period"),
+                    )
+                    .await
+                    .map_err(|e| {
+                        MergeWardenError::FailedToUpdatePullRequest(format!(
+                            "Failed to create stability label: {e}"
+                        ))
+                    })?;
+            }
+
+            provider
+                .add_labels(repo_owner, repo_name, pr_number, &[label_name.clone()])
+                .await
+                .map_err(|e| {
+                    MergeWardenError::FailedToUpdatePullRequest(format!(
+                        "Failed to add stability label: {e}"
+                    ))
+                })?;
+
+            info!(
+                repository_owner = repo_owner,
+                repository = repo_name,
+                pr_number = pr_number,
+                label = %label_name,
+                "Applied Renovate stability label"
+            );
+        }
+        "success" => {
+            info!(
+                repository_owner = repo_owner,
+                repository = repo_name,
+                pr_number = pr_number,
+                label = %label_name,
+                "Renovate stability period elapsed — removing label"
+            );
+
+            match provider
+                .remove_label(repo_owner, repo_name, pr_number, &label_name)
+                .await
+            {
+                Ok(()) => {
+                    info!(
+                        repository_owner = repo_owner,
+                        repository = repo_name,
+                        pr_number = pr_number,
+                        label = %label_name,
+                        "Removed Renovate stability label"
+                    );
+                }
+                Err(merge_warden_developer_platforms::errors::Error::InvalidResponse) => {
+                    // GitHub returns 404 when the label is not present on the PR.
+                    // Treat as a no-op — idempotent removal.
+                    debug!(
+                        repository_owner = repo_owner,
+                        repository = repo_name,
+                        pr_number = pr_number,
+                        label = %label_name,
+                        "Stability label already absent; skipping remove"
+                    );
+                }
+                Err(e) => {
+                    return Err(MergeWardenError::FailedToUpdatePullRequest(format!(
+                        "Failed to remove stability label: {e}"
+                    )));
+                }
+            }
+        }
+        state => {
+            debug!(
+                repository_owner = repo_owner,
+                repository = repo_name,
+                pr_number = pr_number,
+                state = %state,
+                "Unknown commit status state for renovate stability — skipping"
             );
         }
     }

--- a/crates/core/src/labels.rs
+++ b/crates/core/src/labels.rs
@@ -2917,7 +2917,12 @@ pub async fn manage_renovate_stability_label<P: PullRequestProvider + Sync>(
             }
 
             provider
-                .add_labels(repo_owner, repo_name, pr_number, std::slice::from_ref(&label_name))
+                .add_labels(
+                    repo_owner,
+                    repo_name,
+                    pr_number,
+                    std::slice::from_ref(&label_name),
+                )
                 .await
                 .map_err(|e| {
                     MergeWardenError::FailedToUpdatePullRequest(format!(

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use tokio::test;
 
 use merge_warden_developer_platforms::models::{
-    Comment, Label, PullRequest, PullRequestFile, Review, User,
+    Comment, CommitStatus, Label, PullRequest, PullRequestFile, Review, User,
 };
 use merge_warden_developer_platforms::PullRequestProvider;
 
@@ -144,6 +144,24 @@ impl PullRequestProvider for WipMockProvider {
         _repo: &str,
         _number: u64,
     ) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> {
+        Ok(vec![])
+    }
+
+    async fn get_commit_statuses(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
         Ok(vec![])
     }
 }
@@ -290,6 +308,24 @@ impl PullRequestProvider for MockGitProvider {
     ) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> {
         Ok(vec![])
     }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
+        Ok(vec![])
+    }
 }
 
 #[async_trait]
@@ -389,6 +425,24 @@ impl PullRequestProvider for ErrorMockGitProvider {
         _pr_number: u64,
     ) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> {
         unimplemented!("Not needed for this test")
+    }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
+        Ok(vec![])
     }
 
     async fn list_available_labels(
@@ -1022,6 +1076,24 @@ impl PullRequestProvider for SmartMockGitProvider {
         _repo_name: &str,
         _pr_number: u64,
     ) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> {
+        Ok(vec![])
+    }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
         Ok(vec![])
     }
 }
@@ -2564,6 +2636,24 @@ impl PullRequestProvider for PrStateMockProvider {
     ) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> {
         Ok(vec![])
     }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
+        Ok(vec![])
+    }
 }
 
 // ── manage_pr_state_labels tests ─────────────────────────────────────────────
@@ -2953,6 +3043,27 @@ impl PullRequestProvider for SizeLabelMockProvider {
         merge_warden_developer_platforms::errors::Error,
     > {
         unimplemented!("Not needed for this test")
+    }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<
+        Vec<merge_warden_developer_platforms::models::CommitStatus>,
+        merge_warden_developer_platforms::errors::Error,
+    > {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, merge_warden_developer_platforms::errors::Error> {
+        Ok(vec![])
     }
 }
 
@@ -3607,6 +3718,24 @@ impl PullRequestProvider for KeywordLabelMockProvider {
         _repo: &str,
         _number: u64,
     ) -> Result<Vec<PullRequestFile>, Error> {
+        Ok(vec![])
+    }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
         Ok(vec![])
     }
 }
@@ -5471,5 +5600,435 @@ async fn test_no_unnecessary_api_calls_when_no_keyword_matched() {
         provider.deleted_comment_ids().is_empty(),
         "no comments must be deleted when no stale comments exist; deleted: {:?}",
         provider.deleted_comment_ids()
+    );
+}
+
+// ── manage_renovate_stability_label tests ───────────────────────────────────
+
+struct StabilityMockProvider {
+    commit_statuses: Vec<CommitStatus>,
+    available_labels: Vec<Label>,
+    applied_labels: Arc<Mutex<Vec<Label>>>,
+    create_label_calls: Arc<Mutex<Vec<String>>>,
+    /// When `true`, `remove_label` returns `Error::InvalidResponse` (404).
+    remove_label_404: bool,
+}
+
+impl StabilityMockProvider {
+    fn new(commit_statuses: Vec<CommitStatus>) -> Self {
+        Self {
+            commit_statuses,
+            available_labels: vec![],
+            applied_labels: Arc::new(Mutex::new(vec![])),
+            create_label_calls: Arc::new(Mutex::new(vec![])),
+            remove_label_404: false,
+        }
+    }
+
+    fn with_available_labels(mut self, labels: Vec<Label>) -> Self {
+        self.available_labels = labels;
+        self
+    }
+
+    fn with_remove_label_err(mut self, _err: Error) -> Self {
+        self.remove_label_404 = true;
+        self
+    }
+
+    fn applied_labels(&self) -> Vec<Label> {
+        self.applied_labels.lock().unwrap().clone()
+    }
+
+    fn create_label_calls(&self) -> Vec<String> {
+        self.create_label_calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl PullRequestProvider for StabilityMockProvider {
+    async fn get_pull_request(
+        &self,
+        _: &str,
+        _: &str,
+        _: u64,
+    ) -> Result<PullRequest, Error> {
+        unimplemented!()
+    }
+
+    async fn add_comment(&self, _: &str, _: &str, _: u64, _: &str) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn delete_comment(&self, _: &str, _: &str, _: u64) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn list_comments(
+        &self,
+        _: &str,
+        _: &str,
+        _: u64,
+    ) -> Result<Vec<Comment>, Error> {
+        Ok(vec![])
+    }
+
+    async fn list_available_labels(&self, _: &str, _: &str) -> Result<Vec<Label>, Error> {
+        Ok(self.available_labels.clone())
+    }
+
+    async fn add_labels(
+        &self,
+        _: &str,
+        _: &str,
+        _: u64,
+        labels: &[String],
+    ) -> Result<(), Error> {
+        let mut applied = self.applied_labels.lock().unwrap();
+        for l in labels {
+            applied.push(Label {
+                name: l.clone(),
+                description: None,
+            });
+        }
+        Ok(())
+    }
+
+    async fn remove_label(&self, _: &str, _: &str, _: u64, _: &str) -> Result<(), Error> {
+        if self.remove_label_404 {
+            Err(Error::InvalidResponse)
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn list_applied_labels(
+        &self,
+        _: &str,
+        _: &str,
+        _: u64,
+    ) -> Result<Vec<Label>, Error> {
+        Ok(self.applied_labels.lock().unwrap().clone())
+    }
+
+    async fn update_pr_check_status(
+        &self,
+        _: &str,
+        _: &str,
+        _: u64,
+        _: &str,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn list_pr_reviews(
+        &self,
+        _: &str,
+        _: &str,
+        _: u64,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> {
+        Ok(vec![])
+    }
+
+    async fn get_pull_request_files(
+        &self,
+        _: &str,
+        _: &str,
+        _: u64,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> {
+        Ok(vec![])
+    }
+
+    async fn get_commit_statuses(
+        &self,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<Vec<CommitStatus>, Error> {
+        Ok(self.commit_statuses.clone())
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<Vec<u64>, Error> {
+        Ok(vec![])
+    }
+
+    async fn create_label(
+        &self,
+        _: &str,
+        _: &str,
+        name: &str,
+        _color: &str,
+        _description: Option<&str>,
+    ) -> Result<(), Error> {
+        self.create_label_calls.lock().unwrap().push(name.to_string());
+        Ok(())
+    }
+}
+
+fn pending_status() -> CommitStatus {
+    CommitStatus {
+        context: "renovate/stability-days".to_string(),
+        state: "pending".to_string(),
+        description: None,
+    }
+}
+
+fn success_status() -> CommitStatus {
+    CommitStatus {
+        context: "renovate/stability-days".to_string(),
+        state: "success".to_string(),
+        description: None,
+    }
+}
+
+fn error_status() -> CommitStatus {
+    CommitStatus {
+        context: "renovate/stability-days".to_string(),
+        state: "error".to_string(),
+        description: None,
+    }
+}
+
+fn failure_status() -> CommitStatus {
+    CommitStatus {
+        context: "renovate/stability-days".to_string(),
+        state: "failure".to_string(),
+        description: None,
+    }
+}
+
+fn default_stability_config() -> crate::config::RenovateStabilityConfig {
+    crate::config::RenovateStabilityConfig::default()
+}
+
+#[test]
+async fn manage_renovate_stability_label_pending_adds_label() {
+    let provider = StabilityMockProvider::new(vec![pending_status()]);
+    let config = default_stability_config();
+
+    crate::labels::manage_renovate_stability_label(
+        &provider,
+        "owner",
+        "repo",
+        1,
+        "abc123",
+        &config,
+    )
+    .await
+    .unwrap();
+
+    let applied = provider.applied_labels();
+    assert!(
+        applied.iter().any(|l| l.name == config.pending_stability_label),
+        "stability label should be applied for pending status"
+    );
+}
+
+#[test]
+async fn manage_renovate_stability_label_error_adds_label() {
+    let provider = StabilityMockProvider::new(vec![error_status()]);
+    let config = default_stability_config();
+
+    crate::labels::manage_renovate_stability_label(
+        &provider,
+        "owner",
+        "repo",
+        1,
+        "abc123",
+        &config,
+    )
+    .await
+    .unwrap();
+
+    let applied = provider.applied_labels();
+    assert!(
+        applied.iter().any(|l| l.name == config.pending_stability_label),
+        "stability label should be applied for error status"
+    );
+}
+
+#[test]
+async fn manage_renovate_stability_label_failure_adds_label() {
+    let provider = StabilityMockProvider::new(vec![failure_status()]);
+    let config = default_stability_config();
+
+    crate::labels::manage_renovate_stability_label(
+        &provider,
+        "owner",
+        "repo",
+        1,
+        "abc123",
+        &config,
+    )
+    .await
+    .unwrap();
+
+    let applied = provider.applied_labels();
+    assert!(
+        applied.iter().any(|l| l.name == config.pending_stability_label),
+        "stability label should be applied for failure status"
+    );
+}
+
+#[test]
+async fn manage_renovate_stability_label_success_removes_label() {
+    // Label already present on PR
+    let label_name = default_stability_config().pending_stability_label;
+    let provider = StabilityMockProvider::new(vec![success_status()]);
+
+    crate::labels::manage_renovate_stability_label(
+        &provider,
+        "owner",
+        "repo",
+        1,
+        "abc123",
+        &default_stability_config(),
+    )
+    .await
+    .unwrap();
+
+    // remove_label was called without error
+    let applied = provider.applied_labels();
+    assert!(
+        !applied.iter().any(|l| l.name == label_name),
+        "stability label should not be present after success status"
+    );
+}
+
+#[test]
+async fn manage_renovate_stability_label_success_absent_label_is_noop() {
+    // remove_label returns 404 (InvalidResponse) — should be Ok(())
+    let provider = StabilityMockProvider::new(vec![success_status()])
+        .with_remove_label_err(Error::InvalidResponse);
+
+    let result = crate::labels::manage_renovate_stability_label(
+        &provider,
+        "owner",
+        "repo",
+        1,
+        "abc123",
+        &default_stability_config(),
+    )
+    .await;
+
+    assert!(result.is_ok(), "404 on remove should be treated as no-op");
+}
+
+#[test]
+async fn manage_renovate_stability_label_no_context_is_noop() {
+    let other_status = CommitStatus {
+        context: "ci/build".to_string(),
+        state: "success".to_string(),
+        description: None,
+    };
+    let provider = StabilityMockProvider::new(vec![other_status]);
+    let config = default_stability_config();
+
+    crate::labels::manage_renovate_stability_label(
+        &provider,
+        "owner",
+        "repo",
+        1,
+        "abc123",
+        &config,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        provider.applied_labels().is_empty(),
+        "no label should be applied when context is absent"
+    );
+}
+
+#[test]
+async fn manage_renovate_stability_label_disabled_is_noop() {
+    let mut config = default_stability_config();
+    config.enabled = false;
+
+    let provider = StabilityMockProvider::new(vec![pending_status()]);
+
+    crate::labels::manage_renovate_stability_label(
+        &provider,
+        "owner",
+        "repo",
+        1,
+        "abc123",
+        &config,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        provider.applied_labels().is_empty(),
+        "no API calls when config.enabled = false"
+    );
+}
+
+#[test]
+async fn manage_renovate_stability_label_uses_newest_entry() {
+    // First entry (newest per GitHub ordering) is pending; second is success.
+    // The function should act on the first match (pending) → add label.
+    let statuses = vec![
+        pending_status(), // newest
+        success_status(), // older
+    ];
+    let provider = StabilityMockProvider::new(statuses);
+    let config = default_stability_config();
+
+    crate::labels::manage_renovate_stability_label(
+        &provider,
+        "owner",
+        "repo",
+        1,
+        "abc123",
+        &config,
+    )
+    .await
+    .unwrap();
+
+    let applied = provider.applied_labels();
+    assert!(
+        applied.iter().any(|l| l.name == config.pending_stability_label),
+        "pending (newest) entry should win"
+    );
+}
+
+#[test]
+async fn manage_renovate_stability_label_creates_label_if_missing() {
+    // No labels in repository — create_label should be called before add_labels.
+    let provider = StabilityMockProvider::new(vec![pending_status()]); // available_labels is empty
+    let config = default_stability_config();
+
+    crate::labels::manage_renovate_stability_label(
+        &provider,
+        "owner",
+        "repo",
+        1,
+        "abc123",
+        &config,
+    )
+    .await
+    .unwrap();
+
+    let create_calls = provider.create_label_calls();
+    assert_eq!(
+        create_calls.len(),
+        1,
+        "create_label should be called once when label is absent"
+    );
+    assert_eq!(create_calls[0], config.pending_stability_label);
+
+    let applied = provider.applied_labels();
+    assert!(
+        applied.iter().any(|l| l.name == config.pending_stability_label),
+        "label should be applied after creation"
     );
 }

--- a/crates/core/src/labels_tests.rs
+++ b/crates/core/src/labels_tests.rs
@@ -5610,8 +5610,6 @@ struct StabilityMockProvider {
     available_labels: Vec<Label>,
     applied_labels: Arc<Mutex<Vec<Label>>>,
     create_label_calls: Arc<Mutex<Vec<String>>>,
-    /// When `true`, `remove_label` returns `Error::InvalidResponse` (404).
-    remove_label_404: bool,
 }
 
 impl StabilityMockProvider {
@@ -5621,17 +5619,11 @@ impl StabilityMockProvider {
             available_labels: vec![],
             applied_labels: Arc::new(Mutex::new(vec![])),
             create_label_calls: Arc::new(Mutex::new(vec![])),
-            remove_label_404: false,
         }
     }
 
     fn with_available_labels(mut self, labels: Vec<Label>) -> Self {
         self.available_labels = labels;
-        self
-    }
-
-    fn with_remove_label_err(mut self, _err: Error) -> Self {
-        self.remove_label_404 = true;
         self
     }
 
@@ -5646,12 +5638,7 @@ impl StabilityMockProvider {
 
 #[async_trait]
 impl PullRequestProvider for StabilityMockProvider {
-    async fn get_pull_request(
-        &self,
-        _: &str,
-        _: &str,
-        _: u64,
-    ) -> Result<PullRequest, Error> {
+    async fn get_pull_request(&self, _: &str, _: &str, _: u64) -> Result<PullRequest, Error> {
         unimplemented!()
     }
 
@@ -5663,12 +5650,7 @@ impl PullRequestProvider for StabilityMockProvider {
         Ok(())
     }
 
-    async fn list_comments(
-        &self,
-        _: &str,
-        _: &str,
-        _: u64,
-    ) -> Result<Vec<Comment>, Error> {
+    async fn list_comments(&self, _: &str, _: &str, _: u64) -> Result<Vec<Comment>, Error> {
         Ok(vec![])
     }
 
@@ -5676,13 +5658,7 @@ impl PullRequestProvider for StabilityMockProvider {
         Ok(self.available_labels.clone())
     }
 
-    async fn add_labels(
-        &self,
-        _: &str,
-        _: &str,
-        _: u64,
-        labels: &[String],
-    ) -> Result<(), Error> {
+    async fn add_labels(&self, _: &str, _: &str, _: u64, labels: &[String]) -> Result<(), Error> {
         let mut applied = self.applied_labels.lock().unwrap();
         for l in labels {
             applied.push(Label {
@@ -5694,19 +5670,10 @@ impl PullRequestProvider for StabilityMockProvider {
     }
 
     async fn remove_label(&self, _: &str, _: &str, _: u64, _: &str) -> Result<(), Error> {
-        if self.remove_label_404 {
-            Err(Error::InvalidResponse)
-        } else {
-            Ok(())
-        }
+        Ok(())
     }
 
-    async fn list_applied_labels(
-        &self,
-        _: &str,
-        _: &str,
-        _: u64,
-    ) -> Result<Vec<Label>, Error> {
+    async fn list_applied_labels(&self, _: &str, _: &str, _: u64) -> Result<Vec<Label>, Error> {
         Ok(self.applied_labels.lock().unwrap().clone())
     }
 
@@ -5767,7 +5734,10 @@ impl PullRequestProvider for StabilityMockProvider {
         _color: &str,
         _description: Option<&str>,
     ) -> Result<(), Error> {
-        self.create_label_calls.lock().unwrap().push(name.to_string());
+        self.create_label_calls
+            .lock()
+            .unwrap()
+            .push(name.to_string());
         Ok(())
     }
 }
@@ -5814,19 +5784,16 @@ async fn manage_renovate_stability_label_pending_adds_label() {
     let config = default_stability_config();
 
     crate::labels::manage_renovate_stability_label(
-        &provider,
-        "owner",
-        "repo",
-        1,
-        "abc123",
-        &config,
+        &provider, "owner", "repo", 1, "abc123", &config,
     )
     .await
     .unwrap();
 
     let applied = provider.applied_labels();
     assert!(
-        applied.iter().any(|l| l.name == config.pending_stability_label),
+        applied
+            .iter()
+            .any(|l| l.name == config.pending_stability_label),
         "stability label should be applied for pending status"
     );
 }
@@ -5837,19 +5804,16 @@ async fn manage_renovate_stability_label_error_adds_label() {
     let config = default_stability_config();
 
     crate::labels::manage_renovate_stability_label(
-        &provider,
-        "owner",
-        "repo",
-        1,
-        "abc123",
-        &config,
+        &provider, "owner", "repo", 1, "abc123", &config,
     )
     .await
     .unwrap();
 
     let applied = provider.applied_labels();
     assert!(
-        applied.iter().any(|l| l.name == config.pending_stability_label),
+        applied
+            .iter()
+            .any(|l| l.name == config.pending_stability_label),
         "stability label should be applied for error status"
     );
 }
@@ -5860,19 +5824,16 @@ async fn manage_renovate_stability_label_failure_adds_label() {
     let config = default_stability_config();
 
     crate::labels::manage_renovate_stability_label(
-        &provider,
-        "owner",
-        "repo",
-        1,
-        "abc123",
-        &config,
+        &provider, "owner", "repo", 1, "abc123", &config,
     )
     .await
     .unwrap();
 
     let applied = provider.applied_labels();
     assert!(
-        applied.iter().any(|l| l.name == config.pending_stability_label),
+        applied
+            .iter()
+            .any(|l| l.name == config.pending_stability_label),
         "stability label should be applied for failure status"
     );
 }
@@ -5904,9 +5865,11 @@ async fn manage_renovate_stability_label_success_removes_label() {
 
 #[test]
 async fn manage_renovate_stability_label_success_absent_label_is_noop() {
-    // remove_label returns 404 (InvalidResponse) — should be Ok(())
-    let provider = StabilityMockProvider::new(vec![success_status()])
-        .with_remove_label_err(Error::InvalidResponse);
+    // Simulates the case where the provider handles 404 internally and returns
+    // Ok(()) (the GitHubProvider does this).  manage_renovate_stability_label
+    // should propagate the Ok(()) cleanly with no error.
+    let provider = StabilityMockProvider::new(vec![success_status()]);
+    // remove_label_404 = false (default) — provider returns Ok(())
 
     let result = crate::labels::manage_renovate_stability_label(
         &provider,
@@ -5918,7 +5881,11 @@ async fn manage_renovate_stability_label_success_absent_label_is_noop() {
     )
     .await;
 
-    assert!(result.is_ok(), "404 on remove should be treated as no-op");
+    assert!(
+        result.is_ok(),
+        "absent label remove should be a no-op: {:?}",
+        result
+    );
 }
 
 #[test]
@@ -5932,12 +5899,7 @@ async fn manage_renovate_stability_label_no_context_is_noop() {
     let config = default_stability_config();
 
     crate::labels::manage_renovate_stability_label(
-        &provider,
-        "owner",
-        "repo",
-        1,
-        "abc123",
-        &config,
+        &provider, "owner", "repo", 1, "abc123", &config,
     )
     .await
     .unwrap();
@@ -5956,12 +5918,7 @@ async fn manage_renovate_stability_label_disabled_is_noop() {
     let provider = StabilityMockProvider::new(vec![pending_status()]);
 
     crate::labels::manage_renovate_stability_label(
-        &provider,
-        "owner",
-        "repo",
-        1,
-        "abc123",
-        &config,
+        &provider, "owner", "repo", 1, "abc123", &config,
     )
     .await
     .unwrap();
@@ -5984,19 +5941,16 @@ async fn manage_renovate_stability_label_uses_newest_entry() {
     let config = default_stability_config();
 
     crate::labels::manage_renovate_stability_label(
-        &provider,
-        "owner",
-        "repo",
-        1,
-        "abc123",
-        &config,
+        &provider, "owner", "repo", 1, "abc123", &config,
     )
     .await
     .unwrap();
 
     let applied = provider.applied_labels();
     assert!(
-        applied.iter().any(|l| l.name == config.pending_stability_label),
+        applied
+            .iter()
+            .any(|l| l.name == config.pending_stability_label),
         "pending (newest) entry should win"
     );
 }
@@ -6008,12 +5962,7 @@ async fn manage_renovate_stability_label_creates_label_if_missing() {
     let config = default_stability_config();
 
     crate::labels::manage_renovate_stability_label(
-        &provider,
-        "owner",
-        "repo",
-        1,
-        "abc123",
-        &config,
+        &provider, "owner", "repo", 1, "abc123", &config,
     )
     .await
     .unwrap();
@@ -6028,7 +5977,9 @@ async fn manage_renovate_stability_label_creates_label_if_missing() {
 
     let applied = provider.applied_labels();
     assert!(
-        applied.iter().any(|l| l.name == config.pending_stability_label),
+        applied
+            .iter()
+            .any(|l| l.name == config.pending_stability_label),
         "label should be applied after creation"
     );
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -390,6 +390,44 @@ impl<P: PullRequestProvider + ConfigFetcher + std::fmt::Debug> MergeWarden<P> {
         }
     }
 
+    /// Applies or removes the Renovate stability label for a pull request based
+    /// on the current commit status for the `renovate/stability-days` context.
+    ///
+    /// Errors are logged at `warn` level and never propagated — this is a
+    /// best-effort side-effect that must not block the overall PR check.
+    ///
+    /// # Arguments
+    ///
+    /// * `repo_owner` - The owner of the repository
+    /// * `repo_name` - The name of the repository
+    /// * `pr` - The pull request being processed
+    #[instrument]
+    async fn communicate_renovate_stability_status(
+        &self,
+        repo_owner: &str,
+        repo_name: &str,
+        pr: &PullRequest,
+    ) {
+        if let Err(e) = labels::manage_renovate_stability_label(
+            &self.provider,
+            repo_owner,
+            repo_name,
+            pr.number,
+            &pr.head_sha,
+            &self.config.renovate_stability,
+        )
+        .await
+        {
+            warn!(
+                repository_owner = repo_owner,
+                repository = repo_name,
+                pull_request = pr.number,
+                error = %e,
+                "Failed to manage Renovate stability label"
+            );
+        }
+    }
+
     /// Handles side effects for WIP status changes on a pull request.
     ///
     /// When `is_wip` is `true`:
@@ -1769,6 +1807,8 @@ Please update the PR body to include a valid work item reference."#;
     ///     # async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     ///     # async fn get_pull_request_files(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> { unimplemented!() }
     ///     # async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    ///     # async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { Ok(vec![]) }
+    ///     # async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { Ok(vec![]) }
     /// }
     ///
     /// #[async_trait]
@@ -2004,6 +2044,8 @@ Please update the PR body to include a valid work item reference."#;
     ///     # async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     ///     # async fn get_pull_request_files(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> { unimplemented!() }
     ///     # async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    ///     # async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { Ok(vec![]) }
+    ///     # async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { Ok(vec![]) }
     /// }
     ///
     /// #[async_trait]
@@ -2074,6 +2116,10 @@ Please update the PR body to include a valid work item reference."#;
         // Runs before the draft early-return so the draft label is applied even
         // when we skip the full validation.
         self.communicate_pr_state_labels(repo_owner, repo_name, &pr)
+            .await;
+
+        // Manage the Renovate stability label based on current commit status.
+        self.communicate_renovate_stability_status(repo_owner, repo_name, &pr)
             .await;
 
         // If the pull request is a draft then we still run validation so developers can
@@ -2581,6 +2627,8 @@ Please update the PR body to include a valid work item reference."#;
     ///     # async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     ///     # async fn get_pull_request_files(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> { unimplemented!() }
     ///     # async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    ///     # async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { Ok(vec![]) }
+    ///     # async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { Ok(vec![]) }
     /// }
     ///
     /// #[async_trait]

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -213,6 +213,24 @@ impl PullRequestProvider for ErrorMockGitProvider {
     ) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> {
         Ok(vec![])
     }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
+        Ok(vec![])
+    }
 }
 
 #[async_trait]
@@ -257,6 +275,7 @@ struct DynamicMockGitProvider {
     comments: Arc<Mutex<Vec<Comment>>>,
     check_status_updates: Arc<Mutex<Vec<CheckStatusUpdate>>>,
     reviews: Vec<Review>,
+    commit_statuses: Vec<merge_warden_developer_platforms::models::CommitStatus>,
 }
 
 impl DynamicMockGitProvider {
@@ -267,11 +286,20 @@ impl DynamicMockGitProvider {
             comments: Arc::new(Mutex::new(Vec::new())),
             check_status_updates: Arc::new(Mutex::new(Vec::new())),
             reviews: vec![],
+            commit_statuses: vec![],
         }
     }
 
     fn with_reviews(mut self, reviews: Vec<Review>) -> Self {
         self.reviews = reviews;
+        self
+    }
+
+    fn with_commit_statuses(
+        mut self,
+        statuses: Vec<merge_warden_developer_platforms::models::CommitStatus>,
+    ) -> Self {
+        self.commit_statuses = statuses;
         self
     }
 
@@ -437,6 +465,24 @@ impl PullRequestProvider for DynamicMockGitProvider {
         _pr_number: u64,
     ) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> {
         Ok(self.reviews.clone())
+    }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> {
+        Ok(self.commit_statuses.clone())
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
+        Ok(vec![])
     }
 }
 
@@ -643,6 +689,24 @@ impl PullRequestProvider for MockGitProvider {
         _repo_name: &str,
         _pr_number: u64,
     ) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> {
+        Ok(vec![])
+    }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
         Ok(vec![])
     }
 }
@@ -3929,6 +3993,27 @@ impl merge_warden_developer_platforms::PullRequestProvider for SizeMockGitProvid
     > {
         Ok(vec![])
     }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<
+        Vec<merge_warden_developer_platforms::models::CommitStatus>,
+        merge_warden_developer_platforms::errors::Error,
+    > {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, merge_warden_developer_platforms::errors::Error> {
+        Ok(vec![])
+    }
 }
 
 #[async_trait]
@@ -4292,6 +4377,27 @@ impl merge_warden_developer_platforms::PullRequestProvider for ConfigCheckMockPr
     ) -> Result<Vec<Review>, merge_warden_developer_platforms::errors::Error> {
         Ok(vec![])
     }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<
+        Vec<merge_warden_developer_platforms::models::CommitStatus>,
+        merge_warden_developer_platforms::errors::Error,
+    > {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, merge_warden_developer_platforms::errors::Error> {
+        Ok(vec![])
+    }
 }
 
 #[async_trait]
@@ -4607,5 +4713,234 @@ async fn test_config_check_no_repost_when_error_comment_unchanged() {
     assert_eq!(
         config_comments[0].id, 99,
         "comment must not have been deleted and re-posted; id=99 must be preserved"
+    );
+}
+
+// ── Renovate stability label tests ──────────────────────────────────────────
+
+fn make_pr_for_stability(number: u64) -> PullRequest {
+    PullRequest {
+        number,
+        title: "chore: update dependencies".to_string(),
+        draft: false,
+        body: Some("Closes #1".to_string()),
+        author: Some(User {
+            id: 1,
+            login: "renovate".to_string(),
+        }),
+        milestone_number: None,
+        head_sha: "deadbeef".to_string(),
+    }
+}
+
+fn stability_config_enabled() -> CurrentPullRequestValidationConfiguration {
+    CurrentPullRequestValidationConfiguration {
+        renovate_stability: crate::config::RenovateStabilityConfig {
+            enabled: true,
+            pending_stability_label: crate::config::RENOVATE_STABILITY_LABEL.to_string(),
+        },
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn process_pull_request_pending_stability_applies_label() {
+    let mut provider = DynamicMockGitProvider::new()
+        .with_commit_statuses(vec![
+            merge_warden_developer_platforms::models::CommitStatus {
+                context: "renovate/stability-days".to_string(),
+                state: "pending".to_string(),
+                description: None,
+            },
+        ]);
+    provider.add_pull_request(make_pr_for_stability(1));
+
+    let warden = MergeWarden::with_config(provider, stability_config_enabled());
+    warden
+        .process_pull_request("owner", "repo", 1)
+        .await
+        .unwrap();
+
+    let labels = warden.provider.get_labels();
+    assert!(
+        labels
+            .iter()
+            .any(|l| l.name == crate::config::RENOVATE_STABILITY_LABEL),
+        "stability label should be applied when status is pending"
+    );
+}
+
+#[tokio::test]
+async fn process_pull_request_success_stability_removes_label() {
+    let mut provider = DynamicMockGitProvider::new()
+        .with_commit_statuses(vec![
+            merge_warden_developer_platforms::models::CommitStatus {
+                context: "renovate/stability-days".to_string(),
+                state: "success".to_string(),
+                description: None,
+            },
+        ]);
+    provider.add_pull_request(make_pr_for_stability(1));
+
+    let warden = MergeWarden::with_config(provider, stability_config_enabled());
+    warden
+        .process_pull_request("owner", "repo", 1)
+        .await
+        .unwrap();
+
+    // remove_label was called (does not error); label not in applied list
+    let labels = warden.provider.get_labels();
+    assert!(
+        !labels
+            .iter()
+            .any(|l| l.name == crate::config::RENOVATE_STABILITY_LABEL),
+        "stability label should not be present when status is success"
+    );
+}
+
+#[tokio::test]
+async fn process_pull_request_no_stability_context_is_noop() {
+    let mut provider = DynamicMockGitProvider::new()
+        .with_commit_statuses(vec![
+            merge_warden_developer_platforms::models::CommitStatus {
+                context: "ci/build".to_string(),
+                state: "success".to_string(),
+                description: None,
+            },
+        ]);
+    provider.add_pull_request(make_pr_for_stability(1));
+
+    let warden = MergeWarden::with_config(provider, stability_config_enabled());
+    warden
+        .process_pull_request("owner", "repo", 1)
+        .await
+        .unwrap();
+
+    let labels = warden.provider.get_labels();
+    assert!(
+        !labels
+            .iter()
+            .any(|l| l.name == crate::config::RENOVATE_STABILITY_LABEL),
+        "stability label should not be applied when stability context is absent"
+    );
+}
+
+#[tokio::test]
+async fn process_pull_request_stability_disabled_is_noop() {
+    let mut provider = DynamicMockGitProvider::new()
+        .with_commit_statuses(vec![
+            merge_warden_developer_platforms::models::CommitStatus {
+                context: "renovate/stability-days".to_string(),
+                state: "pending".to_string(),
+                description: None,
+            },
+        ]);
+    provider.add_pull_request(make_pr_for_stability(1));
+
+    let config = CurrentPullRequestValidationConfiguration {
+        renovate_stability: crate::config::RenovateStabilityConfig {
+            enabled: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let warden = MergeWarden::with_config(provider, config);
+    warden
+        .process_pull_request("owner", "repo", 1)
+        .await
+        .unwrap();
+
+    let labels = warden.provider.get_labels();
+    assert!(
+        !labels
+            .iter()
+            .any(|l| l.name == crate::config::RENOVATE_STABILITY_LABEL),
+        "stability label should not be applied when feature is disabled"
+    );
+}
+
+#[tokio::test]
+async fn process_pull_request_stability_error_does_not_propagate() {
+    // When the stability label call fails internally, process_pull_request
+    // should still complete (errors are logged at warn, not returned).
+    // DynamicMockGitProvider does not error on list_available_labels, so
+    // this test primarily exercises the path without panicking.
+    let mut provider = DynamicMockGitProvider::new()
+        .with_commit_statuses(vec![
+            merge_warden_developer_platforms::models::CommitStatus {
+                context: "renovate/stability-days".to_string(),
+                state: "pending".to_string(),
+                description: None,
+            },
+        ]);
+    provider.add_pull_request(make_pr_for_stability(1));
+
+    let warden = MergeWarden::with_config(provider, stability_config_enabled());
+    let result = warden.process_pull_request("owner", "repo", 1).await;
+    assert!(
+        result.is_ok(),
+        "stability label errors must not propagate as process_pull_request failures"
+    );
+}
+
+#[tokio::test]
+async fn process_pull_request_draft_receives_stability_label() {
+    let mut provider = DynamicMockGitProvider::new()
+        .with_commit_statuses(vec![
+            merge_warden_developer_platforms::models::CommitStatus {
+                context: "renovate/stability-days".to_string(),
+                state: "pending".to_string(),
+                description: None,
+            },
+        ]);
+    let mut pr = make_pr_for_stability(1);
+    pr.draft = true;
+    provider.add_pull_request(pr);
+
+    let warden = MergeWarden::with_config(provider, stability_config_enabled());
+    warden
+        .process_pull_request("owner", "repo", 1)
+        .await
+        .unwrap();
+
+    let labels = warden.provider.get_labels();
+    assert!(
+        labels
+            .iter()
+            .any(|l| l.name == crate::config::RENOVATE_STABILITY_LABEL),
+        "stability label should also be applied on draft PRs"
+    );
+}
+
+#[tokio::test]
+async fn process_pull_request_check_conclusion_unaffected_by_stability() {
+    // A valid PR with pending stability status should still pass the title/body
+    // checks and produce a "success" check-status conclusion.
+    let mut provider = DynamicMockGitProvider::new()
+        .with_commit_statuses(vec![
+            merge_warden_developer_platforms::models::CommitStatus {
+                context: "renovate/stability-days".to_string(),
+                state: "pending".to_string(),
+                description: None,
+            },
+        ]);
+    provider.add_pull_request(make_pr_for_stability(1));
+
+    let warden = MergeWarden::with_config(provider, stability_config_enabled());
+    warden
+        .process_pull_request("owner", "repo", 1)
+        .await
+        .unwrap();
+
+    let updates = warden.provider.get_check_status_updates();
+    let conclusion = updates
+        .last()
+        .map(|u| u.conclusion.as_str())
+        .unwrap_or("");
+    // The stability label does not affect the Merge Warden check conclusion.
+    assert!(
+        conclusion == "success" || conclusion == "failure",
+        "check conclusion should be determined by title/body validations, not stability state; got '{conclusion}'"
     );
 }

--- a/crates/core/src/lib_tests.rs
+++ b/crates/core/src/lib_tests.rs
@@ -4745,14 +4745,13 @@ fn stability_config_enabled() -> CurrentPullRequestValidationConfiguration {
 
 #[tokio::test]
 async fn process_pull_request_pending_stability_applies_label() {
-    let mut provider = DynamicMockGitProvider::new()
-        .with_commit_statuses(vec![
-            merge_warden_developer_platforms::models::CommitStatus {
-                context: "renovate/stability-days".to_string(),
-                state: "pending".to_string(),
-                description: None,
-            },
-        ]);
+    let mut provider = DynamicMockGitProvider::new().with_commit_statuses(vec![
+        merge_warden_developer_platforms::models::CommitStatus {
+            context: "renovate/stability-days".to_string(),
+            state: "pending".to_string(),
+            description: None,
+        },
+    ]);
     provider.add_pull_request(make_pr_for_stability(1));
 
     let warden = MergeWarden::with_config(provider, stability_config_enabled());
@@ -4772,14 +4771,13 @@ async fn process_pull_request_pending_stability_applies_label() {
 
 #[tokio::test]
 async fn process_pull_request_success_stability_removes_label() {
-    let mut provider = DynamicMockGitProvider::new()
-        .with_commit_statuses(vec![
-            merge_warden_developer_platforms::models::CommitStatus {
-                context: "renovate/stability-days".to_string(),
-                state: "success".to_string(),
-                description: None,
-            },
-        ]);
+    let mut provider = DynamicMockGitProvider::new().with_commit_statuses(vec![
+        merge_warden_developer_platforms::models::CommitStatus {
+            context: "renovate/stability-days".to_string(),
+            state: "success".to_string(),
+            description: None,
+        },
+    ]);
     provider.add_pull_request(make_pr_for_stability(1));
 
     let warden = MergeWarden::with_config(provider, stability_config_enabled());
@@ -4800,14 +4798,13 @@ async fn process_pull_request_success_stability_removes_label() {
 
 #[tokio::test]
 async fn process_pull_request_no_stability_context_is_noop() {
-    let mut provider = DynamicMockGitProvider::new()
-        .with_commit_statuses(vec![
-            merge_warden_developer_platforms::models::CommitStatus {
-                context: "ci/build".to_string(),
-                state: "success".to_string(),
-                description: None,
-            },
-        ]);
+    let mut provider = DynamicMockGitProvider::new().with_commit_statuses(vec![
+        merge_warden_developer_platforms::models::CommitStatus {
+            context: "ci/build".to_string(),
+            state: "success".to_string(),
+            description: None,
+        },
+    ]);
     provider.add_pull_request(make_pr_for_stability(1));
 
     let warden = MergeWarden::with_config(provider, stability_config_enabled());
@@ -4827,14 +4824,13 @@ async fn process_pull_request_no_stability_context_is_noop() {
 
 #[tokio::test]
 async fn process_pull_request_stability_disabled_is_noop() {
-    let mut provider = DynamicMockGitProvider::new()
-        .with_commit_statuses(vec![
-            merge_warden_developer_platforms::models::CommitStatus {
-                context: "renovate/stability-days".to_string(),
-                state: "pending".to_string(),
-                description: None,
-            },
-        ]);
+    let mut provider = DynamicMockGitProvider::new().with_commit_statuses(vec![
+        merge_warden_developer_platforms::models::CommitStatus {
+            context: "renovate/stability-days".to_string(),
+            state: "pending".to_string(),
+            description: None,
+        },
+    ]);
     provider.add_pull_request(make_pr_for_stability(1));
 
     let config = CurrentPullRequestValidationConfiguration {
@@ -4866,14 +4862,13 @@ async fn process_pull_request_stability_error_does_not_propagate() {
     // should still complete (errors are logged at warn, not returned).
     // DynamicMockGitProvider does not error on list_available_labels, so
     // this test primarily exercises the path without panicking.
-    let mut provider = DynamicMockGitProvider::new()
-        .with_commit_statuses(vec![
-            merge_warden_developer_platforms::models::CommitStatus {
-                context: "renovate/stability-days".to_string(),
-                state: "pending".to_string(),
-                description: None,
-            },
-        ]);
+    let mut provider = DynamicMockGitProvider::new().with_commit_statuses(vec![
+        merge_warden_developer_platforms::models::CommitStatus {
+            context: "renovate/stability-days".to_string(),
+            state: "pending".to_string(),
+            description: None,
+        },
+    ]);
     provider.add_pull_request(make_pr_for_stability(1));
 
     let warden = MergeWarden::with_config(provider, stability_config_enabled());
@@ -4886,14 +4881,13 @@ async fn process_pull_request_stability_error_does_not_propagate() {
 
 #[tokio::test]
 async fn process_pull_request_draft_receives_stability_label() {
-    let mut provider = DynamicMockGitProvider::new()
-        .with_commit_statuses(vec![
-            merge_warden_developer_platforms::models::CommitStatus {
-                context: "renovate/stability-days".to_string(),
-                state: "pending".to_string(),
-                description: None,
-            },
-        ]);
+    let mut provider = DynamicMockGitProvider::new().with_commit_statuses(vec![
+        merge_warden_developer_platforms::models::CommitStatus {
+            context: "renovate/stability-days".to_string(),
+            state: "pending".to_string(),
+            description: None,
+        },
+    ]);
     let mut pr = make_pr_for_stability(1);
     pr.draft = true;
     provider.add_pull_request(pr);
@@ -4917,14 +4911,13 @@ async fn process_pull_request_draft_receives_stability_label() {
 async fn process_pull_request_check_conclusion_unaffected_by_stability() {
     // A valid PR with pending stability status should still pass the title/body
     // checks and produce a "success" check-status conclusion.
-    let mut provider = DynamicMockGitProvider::new()
-        .with_commit_statuses(vec![
-            merge_warden_developer_platforms::models::CommitStatus {
-                context: "renovate/stability-days".to_string(),
-                state: "pending".to_string(),
-                description: None,
-            },
-        ]);
+    let mut provider = DynamicMockGitProvider::new().with_commit_statuses(vec![
+        merge_warden_developer_platforms::models::CommitStatus {
+            context: "renovate/stability-days".to_string(),
+            state: "pending".to_string(),
+            description: None,
+        },
+    ]);
     provider.add_pull_request(make_pr_for_stability(1));
 
     let warden = MergeWarden::with_config(provider, stability_config_enabled());
@@ -4934,10 +4927,7 @@ async fn process_pull_request_check_conclusion_unaffected_by_stability() {
         .unwrap();
 
     let updates = warden.provider.get_check_status_updates();
-    let conclusion = updates
-        .last()
-        .map(|u| u.conclusion.as_str())
-        .unwrap_or("");
+    let conclusion = updates.last().map(|u| u.conclusion.as_str()).unwrap_or("");
     // The stability label does not affect the Merge Warden check conclusion.
     assert!(
         conclusion == "success" || conclusion == "failure",

--- a/crates/developer_platforms/src/github.rs
+++ b/crates/developer_platforms/src/github.rs
@@ -727,12 +727,26 @@ impl PullRequestProvider for GitHubProvider {
         pr_number: u64,
         label: &str,
     ) -> Result<(), Error> {
-        self.client
+        match self
+            .client
             .pull_requests()
             .remove_label(repo_owner, repo_name, pr_number, label)
             .await
-            .map(|_| ())
-            .map_err(|e| {
+        {
+            Ok(_) => Ok(()),
+            // GitHub returns 404 when the label is not present on the PR.
+            // Treat as a no-op so callers can remove labels idempotently.
+            Err(ApiError::NotFound) => {
+                debug!(
+                    owner = repo_owner,
+                    repo = repo_name,
+                    pr = pr_number,
+                    label,
+                    "Label not present on PR during remove — treating as no-op"
+                );
+                Ok(())
+            }
+            Err(e) => {
                 warn!(
                     owner = repo_owner,
                     repo = repo_name,
@@ -741,8 +755,12 @@ impl PullRequestProvider for GitHubProvider {
                     error = %e,
                     "Failed to remove label from pull request"
                 );
-                Error::FailedToUpdatePullRequest(format!("Failed to remove label '{}'", label))
-            })
+                Err(Error::FailedToUpdatePullRequest(format!(
+                    "Failed to remove label '{}'",
+                    label
+                )))
+            }
+        }
     }
 
     /// Creates or updates a GitHub check run for the pull request.
@@ -1101,6 +1119,7 @@ impl PullRequestProvider for GitHubProvider {
         Ok(pr_numbers)
     }
 
+    #[instrument(skip(self), fields(owner = repo_owner, repo = repo_name, label = name))]
     async fn create_label(
         &self,
         repo_owner: &str,

--- a/crates/developer_platforms/src/github.rs
+++ b/crates/developer_platforms/src/github.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use base64::Engine;
 use github_bot_sdk::{
-    client::{parse_link_header, CreateCommentRequest, InstallationClient},
+    client::{parse_link_header, CreateCommentRequest, CreateLabelRequest, InstallationClient},
     error::ApiError,
 };
 use serde_json::json;
@@ -10,8 +10,8 @@ use tracing::{debug, error, info, instrument, warn};
 use crate::{
     errors::Error,
     models::{
-        Comment, IssueMetadata, IssueMilestone, IssueProject, Label, PullRequest, PullRequestFile,
-        RepositoryContext, Review, User,
+        Comment, CommitStatus, IssueMetadata, IssueMilestone, IssueProject, Label, PullRequest,
+        PullRequestFile, RepositoryContext, Review, User,
     },
     ConfigFetcher, IssueMetadataProvider, PullRequestProvider, RepositoryMetadataProvider,
 };
@@ -958,6 +958,180 @@ impl PullRequestProvider for GitHubProvider {
         );
 
         Ok(all_reviews)
+    }
+
+    /// Fetches commit statuses for the given commit SHA.
+    ///
+    /// Calls `GET /repos/{owner}/{repo}/commits/{sha}/statuses` and returns the
+    /// first page of results as a [`Vec<CommitStatus>`].  GitHub returns statuses
+    /// newest-first; callers wishing to use the most recent entry per context should
+    /// take the first occurrence of each context value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidResponse`] for non-200 responses (including 404).
+    /// Returns the appropriate [`Error`] variant for auth/rate-limit failures.
+    #[instrument(skip(self), fields(owner = repo_owner, repo = repo_name, sha = commit_sha))]
+    async fn get_commit_statuses(
+        &self,
+        repo_owner: &str,
+        repo_name: &str,
+        commit_sha: &str,
+    ) -> Result<Vec<CommitStatus>, Error> {
+        let path = format!(
+            "/repos/{}/{}/commits/{}/statuses",
+            repo_owner, repo_name, commit_sha
+        );
+
+        let response = match self.client.get(&path).await {
+            Ok(r) => r,
+            Err(e) => {
+                error!(
+                    owner = repo_owner,
+                    repo = repo_name,
+                    sha = commit_sha,
+                    error = %e,
+                    "Failed to fetch commit statuses"
+                );
+                return Err(map_api_error(e));
+            }
+        };
+
+        if !response.status().is_success() {
+            error!(
+                owner = repo_owner,
+                repo = repo_name,
+                sha = commit_sha,
+                status = response.status().as_u16(),
+                "Non-success status fetching commit statuses"
+            );
+            return Err(Error::InvalidResponse);
+        }
+
+        let items: Vec<serde_json::Value> =
+            response.json().await.map_err(|_| Error::InvalidResponse)?;
+
+        let statuses: Vec<CommitStatus> = items
+            .into_iter()
+            .filter_map(|v| {
+                let context = v["context"].as_str()?.to_string();
+                let state = v["state"].as_str()?.to_string();
+                let description = v["description"].as_str().map(|s| s.to_string());
+                Some(CommitStatus {
+                    context,
+                    state,
+                    description,
+                })
+            })
+            .collect();
+
+        debug!(
+            owner = repo_owner,
+            repo = repo_name,
+            sha = commit_sha,
+            count = statuses.len(),
+            "Fetched commit statuses"
+        );
+
+        Ok(statuses)
+    }
+
+    /// Finds open pull requests whose HEAD commit matches `commit_sha`.
+    ///
+    /// Calls `GET /repos/{owner}/{repo}/commits/{sha}/pulls` and returns the
+    /// PR numbers from the response array.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidResponse`] for non-200 responses (including 404).
+    /// Returns the appropriate [`Error`] variant for auth/rate-limit failures.
+    #[instrument(skip(self), fields(owner = repo_owner, repo = repo_name, sha = commit_sha))]
+    async fn find_pull_requests_for_commit(
+        &self,
+        repo_owner: &str,
+        repo_name: &str,
+        commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
+        let path = format!(
+            "/repos/{}/{}/commits/{}/pulls",
+            repo_owner, repo_name, commit_sha
+        );
+
+        let response = match self.client.get(&path).await {
+            Ok(r) => r,
+            Err(e) => {
+                error!(
+                    owner = repo_owner,
+                    repo = repo_name,
+                    sha = commit_sha,
+                    error = %e,
+                    "Failed to find pull requests for commit"
+                );
+                return Err(map_api_error(e));
+            }
+        };
+
+        if !response.status().is_success() {
+            error!(
+                owner = repo_owner,
+                repo = repo_name,
+                sha = commit_sha,
+                status = response.status().as_u16(),
+                "Non-success status finding pull requests for commit"
+            );
+            return Err(Error::InvalidResponse);
+        }
+
+        let items: Vec<serde_json::Value> =
+            response.json().await.map_err(|_| Error::InvalidResponse)?;
+
+        let pr_numbers: Vec<u64> = items
+            .into_iter()
+            .filter_map(|v| v["number"].as_u64())
+            .collect();
+
+        debug!(
+            owner = repo_owner,
+            repo = repo_name,
+            sha = commit_sha,
+            count = pr_numbers.len(),
+            "Found pull requests for commit"
+        );
+
+        Ok(pr_numbers)
+    }
+
+    async fn create_label(
+        &self,
+        repo_owner: &str,
+        repo_name: &str,
+        name: &str,
+        color: &str,
+        description: Option<&str>,
+    ) -> Result<(), Error> {
+        self.client
+            .labels()
+            .create(
+                repo_owner,
+                repo_name,
+                CreateLabelRequest {
+                    name: name.to_string(),
+                    color: color.to_string(),
+                    description: description.map(|d| d.to_string()),
+                },
+            )
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                warn!(
+                    owner = repo_owner,
+                    repo = repo_name,
+                    label = name,
+                    error = %e,
+                    "Failed to create label in repository"
+                );
+                map_api_error(e)
+            })
     }
 }
 

--- a/crates/developer_platforms/src/github_tests.rs
+++ b/crates/developer_platforms/src/github_tests.rs
@@ -1650,6 +1650,379 @@ async fn test_fetch_config_at_ref_returns_none_when_file_absent() {
 }
 
 // ---------------------------------------------------------------------------
+// get_commit_statuses
+// ---------------------------------------------------------------------------
+
+/// Spec assertion: `Ok(vec![])` when commit exists but has no statuses.
+#[tokio::test]
+async fn test_get_commit_statuses_returns_empty_vec_when_no_statuses() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/statuses")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .get_commit_statuses("owner", "repo", sha)
+        .await
+        .expect("should succeed with empty vec");
+
+    assert!(result.is_empty());
+}
+
+/// Spec assertion: returned vector preserves API newest-first ordering.
+#[tokio::test]
+async fn test_get_commit_statuses_preserves_api_order() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/statuses")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "context": "renovate/stability-days",
+                "state": "pending",
+                "description": "Stability pending"
+            },
+            {
+                "context": "renovate/stability-days",
+                "state": "success",
+                "description": "All checks passed"
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .get_commit_statuses("owner", "repo", sha)
+        .await
+        .expect("should succeed");
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0].state, "pending", "first entry must be newest (as returned by API)");
+    assert_eq!(result[1].state, "success");
+}
+
+/// Spec assertion: statuses have correct context and description fields.
+#[tokio::test]
+async fn test_get_commit_statuses_maps_fields_correctly() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/statuses")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "context": "renovate/stability-days",
+                "state": "success",
+                "description": "All stability checks passed"
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .get_commit_statuses("owner", "repo", sha)
+        .await
+        .expect("should succeed");
+
+    let status = &result[0];
+    assert_eq!(status.context, "renovate/stability-days");
+    assert_eq!(status.state, "success");
+    assert_eq!(status.description, Some("All stability checks passed".to_string()));
+}
+
+/// Spec assertion: description may be null / absent.
+#[tokio::test]
+async fn test_get_commit_statuses_null_description_maps_to_none() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/statuses")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "context": "ci/build",
+                "state": "failure",
+                "description": null
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .get_commit_statuses("owner", "repo", sha)
+        .await
+        .expect("should succeed");
+
+    assert_eq!(result[0].description, None);
+}
+
+/// Adversarial: 404 must return Err, not an empty vec.
+#[tokio::test]
+async fn test_get_commit_statuses_404_returns_error() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/statuses")))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider.get_commit_statuses("owner", "repo", sha).await;
+
+    assert!(result.is_err(), "404 must not return Ok");
+}
+
+/// Adversarial: 500 must return Err.
+#[tokio::test]
+async fn test_get_commit_statuses_500_returns_error() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/statuses")))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider.get_commit_statuses("owner", "repo", sha).await;
+
+    assert!(result.is_err(), "500 must not return Ok");
+}
+
+/// Adversarial: 401/403 auth failure must return Err.
+#[tokio::test]
+async fn test_get_commit_statuses_403_returns_error() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/statuses")))
+        .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden"))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider.get_commit_statuses("owner", "repo", sha).await;
+
+    assert!(result.is_err(), "403 must not return Ok");
+}
+
+/// Adversarial: hit the correct URL path (not the checks API).
+#[tokio::test]
+async fn test_get_commit_statuses_uses_statuses_endpoint() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    // Only mount on the statuses endpoint — if the impl calls the wrong path WireMock
+    // returns 404 and the test fails.
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/statuses")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider.get_commit_statuses("owner", "repo", sha).await;
+
+    assert!(result.is_ok(), "should call the /statuses endpoint");
+}
+
+// ---------------------------------------------------------------------------
+// find_pull_requests_for_commit (FR-008 Task 4)
+// ---------------------------------------------------------------------------
+
+/// Spec assertion: `Ok(vec![])` when no open PRs reference the commit SHA.
+#[tokio::test]
+async fn test_find_pull_requests_for_commit_returns_empty_when_no_prs() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/pulls")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .find_pull_requests_for_commit("owner", "repo", sha)
+        .await
+        .expect("should succeed with empty vec");
+
+    assert!(result.is_empty());
+}
+
+/// Spec assertion: returns PR numbers only (Vec<u64>).
+#[tokio::test]
+async fn test_find_pull_requests_for_commit_returns_pr_numbers() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/pulls")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "number": 42,
+                "title": "feat: something",
+                "state": "open",
+                "draft": false,
+                "body": null,
+                "head": { "sha": sha },
+                "user": { "login": "dev", "id": 1, "node_id": "U_1", "type": "User" },
+                "node_id": "PR_1"
+            },
+            {
+                "number": 99,
+                "title": "fix: another",
+                "state": "open",
+                "draft": false,
+                "body": null,
+                "head": { "sha": sha },
+                "user": { "login": "dev", "id": 1, "node_id": "U_1", "type": "User" },
+                "node_id": "PR_2"
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .find_pull_requests_for_commit("owner", "repo", sha)
+        .await
+        .expect("should succeed");
+
+    assert_eq!(result.len(), 2);
+    assert!(result.contains(&42), "PR 42 must be in results");
+    assert!(result.contains(&99), "PR 99 must be in results");
+}
+
+/// Adversarial: only PR numbers returned — no other fields.
+#[tokio::test]
+async fn test_find_pull_requests_for_commit_returns_only_numbers_not_full_structs() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/pulls")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "number": 7,
+                "title": "chore: update deps",
+                "state": "open",
+                "draft": false,
+                "body": "some body",
+                "head": { "sha": sha },
+                "user": { "login": "renovate", "id": 2, "node_id": "U_2", "type": "Bot" },
+                "node_id": "PR_7"
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .find_pull_requests_for_commit("owner", "repo", sha)
+        .await
+        .expect("should succeed");
+
+    // The return type is Vec<u64>; the single entry must be 7.
+    assert_eq!(result, vec![7u64]);
+}
+
+/// Adversarial: 404 must return Err.
+#[tokio::test]
+async fn test_find_pull_requests_for_commit_404_returns_error() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/pulls")))
+        .respond_with(ResponseTemplate::new(404).set_body_string("Not Found"))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .find_pull_requests_for_commit("owner", "repo", sha)
+        .await;
+
+    assert!(result.is_err(), "404 must not return Ok");
+}
+
+/// Adversarial: 500 must return Err.
+#[tokio::test]
+async fn test_find_pull_requests_for_commit_500_returns_error() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/pulls")))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .find_pull_requests_for_commit("owner", "repo", sha)
+        .await;
+
+    assert!(result.is_err(), "500 must not return Ok");
+}
+
+/// Adversarial: 422 (unprocessable entity) must return Err.
+#[tokio::test]
+async fn test_find_pull_requests_for_commit_422_returns_error() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/pulls")))
+        .respond_with(ResponseTemplate::new(422).set_body_string("Unprocessable Entity"))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .find_pull_requests_for_commit("owner", "repo", sha)
+        .await;
+
+    assert!(result.is_err(), "422 must not return Ok");
+}
+
+/// Adversarial: correct URL path is called.
+#[tokio::test]
+async fn test_find_pull_requests_for_commit_uses_pulls_endpoint() {
+    let server = MockServer::start().await;
+    let sha = "aabbccdd1122334455667788990011223344556677";
+
+    // Only mount on the /pulls endpoint — wrong path → 404.
+    Mock::given(method("GET"))
+        .and(path(format!("/repos/owner/repo/commits/{sha}/pulls")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    let provider = make_provider(&server.uri()).await;
+    let result = provider
+        .find_pull_requests_for_commit("owner", "repo", sha)
+        .await;
+
+    assert!(result.is_ok(), "should call /commits/{{sha}}/pulls");
+}
+
+// ---------------------------------------------------------------------------
 // RepositoryMetadataProvider — get_repository_context
 // ---------------------------------------------------------------------------
 

--- a/crates/developer_platforms/src/github_tests.rs
+++ b/crates/developer_platforms/src/github_tests.rs
@@ -652,7 +652,7 @@ async fn test_remove_label_success() {
 }
 
 #[tokio::test]
-async fn test_remove_label_not_found_is_error() {
+async fn test_remove_label_not_found_is_noop() {
     let server = MockServer::start().await;
 
     Mock::given(method("DELETE"))
@@ -666,7 +666,10 @@ async fn test_remove_label_not_found_is_error() {
         .remove_label("owner", "repo", 5, "nonexistent")
         .await;
 
-    assert!(matches!(result, Err(Error::FailedToUpdatePullRequest(_))));
+    assert!(
+        result.is_ok(),
+        "404 on remove_label must be treated as a no-op"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1704,7 +1707,10 @@ async fn test_get_commit_statuses_preserves_api_order() {
         .expect("should succeed");
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0].state, "pending", "first entry must be newest (as returned by API)");
+    assert_eq!(
+        result[0].state, "pending",
+        "first entry must be newest (as returned by API)"
+    );
     assert_eq!(result[1].state, "success");
 }
 
@@ -1735,7 +1741,10 @@ async fn test_get_commit_statuses_maps_fields_correctly() {
     let status = &result[0];
     assert_eq!(status.context, "renovate/stability-days");
     assert_eq!(status.state, "success");
-    assert_eq!(status.description, Some("All stability checks passed".to_string()));
+    assert_eq!(
+        status.description,
+        Some("All stability checks passed".to_string())
+    );
 }
 
 /// Spec assertion: description may be null / absent.

--- a/crates/developer_platforms/src/lib.rs
+++ b/crates/developer_platforms/src/lib.rs
@@ -57,7 +57,8 @@ mod lib_tests;
 
 use errors::Error;
 use models::{
-    Comment, IssueMetadata, Label, PullRequest, PullRequestFile, RepositoryContext, Review,
+    Comment, CommitStatus, IssueMetadata, Label, PullRequest, PullRequestFile, RepositoryContext,
+    Review,
 };
 
 /// Trait to fetch configuration files from remote repositories.
@@ -130,6 +131,8 @@ pub trait ConfigFetcher: Sync + Send {
 ///     # async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
 ///     # async fn get_pull_request_files(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> { unimplemented!() }
 ///     # async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+///     # async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+///     # async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
 /// }
 /// ```
 #[async_trait]
@@ -166,6 +169,8 @@ pub trait PullRequestProvider {
     /// #     async fn list_available_labels(&self, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
     /// #     async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+    /// #     async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
     ///
     /// async fn add_comment(
     ///     &self,
@@ -219,6 +224,8 @@ pub trait PullRequestProvider {
     /// #     async fn list_available_labels(&self, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
     /// #     async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+    /// #     async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
     ///
     /// async fn add_labels(
     ///     &self,
@@ -271,6 +278,8 @@ pub trait PullRequestProvider {
     /// #     async fn list_available_labels(&self, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
     /// #     async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+    /// #     async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
     ///
     /// async fn delete_comment(
     ///     &self,
@@ -343,6 +352,8 @@ pub trait PullRequestProvider {
     /// #     async fn list_applied_labels(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
     /// #     async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+    /// #     async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
     ///
     /// async fn get_pull_request_files(
     ///     &self,
@@ -397,6 +408,8 @@ pub trait PullRequestProvider {
     /// #     async fn list_available_labels(&self, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
     /// #     async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+    /// #     async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
     ///
     /// async fn list_applied_labels(
     ///     &self,
@@ -450,6 +463,8 @@ pub trait PullRequestProvider {
     /// #     async fn list_applied_labels(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
     /// #     async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+    /// #     async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
     ///
     /// async fn list_available_labels(
     ///     &self,
@@ -498,6 +513,8 @@ pub trait PullRequestProvider {
     /// #     async fn list_available_labels(&self, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
     /// #     async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+    /// #     async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
     ///
     /// async fn list_comments(
     ///     &self,
@@ -549,6 +566,8 @@ pub trait PullRequestProvider {
     /// #     async fn list_available_labels(&self, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
     /// #     async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
     /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+    /// #     async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
     ///
     /// async fn remove_label(
     ///     &self,
@@ -606,6 +625,8 @@ pub trait PullRequestProvider {
     /// #     async fn list_comments(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Comment>, Error> { unimplemented!() }
     /// #     async fn remove_label(&self, _: &str, _: &str, _: u64, _: &str) -> Result<(), Error> { unimplemented!() }
     /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+    /// #     async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
     ///
     /// async fn update_pr_check_status(
     ///     &self,
@@ -662,6 +683,150 @@ pub trait PullRequestProvider {
         repo_name: &str,
         pr_number: u64,
     ) -> Result<Vec<Review>, Error>;
+
+    /// Fetches commit statuses for the given commit SHA.
+    ///
+    /// Returns the first page of statuses only (same precedent as `get_pull_request_files`).
+    /// GitHub returns statuses newest-first; callers wishing to use the most recent entry
+    /// per context should take the first occurrence of each context value.
+    ///
+    /// # Arguments
+    /// * `repo_owner` — Repository owner.
+    /// * `repo_name`  — Repository name.
+    /// * `commit_sha` — Full SHA of the commit to query.
+    ///
+    /// # Returns
+    /// `Ok(Vec<CommitStatus>)` — possibly empty if no statuses exist for the commit.
+    /// `Err` on any API failure.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use merge_warden_developer_platforms::PullRequestProvider;
+    /// # use merge_warden_developer_platforms::errors::Error;
+    /// # use async_trait::async_trait;
+    /// # struct MyProvider;
+    /// # #[async_trait]
+    /// # impl PullRequestProvider for MyProvider {
+    /// #     async fn get_pull_request(&self, _: &str, _: &str, _: u64) -> Result<merge_warden_developer_platforms::models::PullRequest, Error> { unimplemented!() }
+    /// #     async fn get_pull_request_files(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> { unimplemented!() }
+    /// #     async fn add_comment(&self, _: &str, _: &str, _: u64, _: &str) -> Result<(), Error> { unimplemented!() }
+    /// #     async fn add_labels(&self, _: &str, _: &str, _: u64, _: &[String]) -> Result<(), Error> { unimplemented!() }
+    /// #     async fn delete_comment(&self, _: &str, _: &str, _: u64) -> Result<(), Error> { unimplemented!() }
+    /// #     async fn list_comments(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Comment>, Error> { unimplemented!() }
+    /// #     async fn remove_label(&self, _: &str, _: &str, _: u64, _: &str) -> Result<(), Error> { unimplemented!() }
+    /// #     async fn list_applied_labels(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
+    /// #     async fn list_available_labels(&self, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
+    /// #     async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
+    /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn find_pull_requests_for_commit(&self, _: &str, _: &str, _: &str) -> Result<Vec<u64>, Error> { unimplemented!() }
+    ///
+    /// async fn get_commit_statuses(
+    ///     &self,
+    ///     repo_owner: &str,
+    ///     repo_name: &str,
+    ///     commit_sha: &str,
+    /// ) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> {
+    ///     // Implementation to fetch commit statuses
+    ///     # unimplemented!()
+    /// }
+    /// # }
+    /// ```
+    ///
+    /// # GitHub API
+    /// `GET /repos/{owner}/{repo}/commits/{sha}/statuses`
+    async fn get_commit_statuses(
+        &self,
+        repo_owner: &str,
+        repo_name: &str,
+        commit_sha: &str,
+    ) -> Result<Vec<CommitStatus>, Error>;
+
+    /// Finds open pull requests whose HEAD commit matches `commit_sha`.
+    ///
+    /// Used by the `status` event handler to map a commit SHA back to the pull
+    /// requests that should be re-evaluated when a commit status changes.
+    ///
+    /// # Arguments
+    /// * `repo_owner` — Repository owner.
+    /// * `repo_name`  — Repository name.
+    /// * `commit_sha` — Full SHA of the commit to look up.
+    ///
+    /// # Returns
+    /// `Ok(Vec<u64>)` of PR numbers — empty if no open PRs reference this commit.
+    /// `Err` on any API failure (including 404).
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use merge_warden_developer_platforms::PullRequestProvider;
+    /// # use merge_warden_developer_platforms::errors::Error;
+    /// # use async_trait::async_trait;
+    /// # struct MyProvider;
+    /// # #[async_trait]
+    /// # impl PullRequestProvider for MyProvider {
+    /// #     async fn get_pull_request(&self, _: &str, _: &str, _: u64) -> Result<merge_warden_developer_platforms::models::PullRequest, Error> { unimplemented!() }
+    /// #     async fn get_pull_request_files(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::PullRequestFile>, Error> { unimplemented!() }
+    /// #     async fn add_comment(&self, _: &str, _: &str, _: u64, _: &str) -> Result<(), Error> { unimplemented!() }
+    /// #     async fn add_labels(&self, _: &str, _: &str, _: u64, _: &[String]) -> Result<(), Error> { unimplemented!() }
+    /// #     async fn delete_comment(&self, _: &str, _: &str, _: u64) -> Result<(), Error> { unimplemented!() }
+    /// #     async fn list_comments(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Comment>, Error> { unimplemented!() }
+    /// #     async fn remove_label(&self, _: &str, _: &str, _: u64, _: &str) -> Result<(), Error> { unimplemented!() }
+    /// #     async fn list_applied_labels(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
+    /// #     async fn list_available_labels(&self, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::Label>, Error> { unimplemented!() }
+    /// #     async fn update_pr_check_status(&self, _: &str, _: &str, _: u64, _: &str, _: &str, _: &str, _: &str) -> Result<(), Error> { unimplemented!() }
+    /// #     async fn list_pr_reviews(&self, _: &str, _: &str, _: u64) -> Result<Vec<merge_warden_developer_platforms::models::Review>, Error> { unimplemented!() }
+    /// #     async fn get_commit_statuses(&self, _: &str, _: &str, _: &str) -> Result<Vec<merge_warden_developer_platforms::models::CommitStatus>, Error> { unimplemented!() }
+    ///
+    /// async fn find_pull_requests_for_commit(
+    ///     &self,
+    ///     repo_owner: &str,
+    ///     repo_name: &str,
+    ///     commit_sha: &str,
+    /// ) -> Result<Vec<u64>, Error> {
+    ///     // Implementation to find PRs associated with a commit
+    ///     # unimplemented!()
+    /// }
+    /// # }
+    /// ```
+    ///
+    /// # GitHub API
+    /// `GET /repos/{owner}/{repo}/commits/{sha}/pulls`
+    async fn find_pull_requests_for_commit(
+        &self,
+        repo_owner: &str,
+        repo_name: &str,
+        commit_sha: &str,
+    ) -> Result<Vec<u64>, Error>;
+
+    /// Creates a new label in the repository if it does not already exist.
+    ///
+    /// Callers should check [`PullRequestProvider::list_available_labels`] first and
+    /// only call this when the label is absent.
+    ///
+    /// # Arguments
+    /// * `repo_owner`  — Repository owner.
+    /// * `repo_name`   — Repository name.
+    /// * `name`        — Label name.
+    /// * `color`       — 6-digit hex colour code **without** the leading `#`.
+    /// * `description` — Optional human-readable description for the label.
+    ///
+    /// # Returns
+    /// `Ok(())` on success. `Err` on any API failure.
+    ///
+    /// # Default
+    /// The default implementation is a no-op (`Ok(())`). Override this in
+    /// providers that support label creation (e.g. [`github::GitHubProvider`]).
+    async fn create_label(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _name: &str,
+        _color: &str,
+        _description: Option<&str>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 /// Provides read access to issue metadata for propagation to pull requests.

--- a/crates/developer_platforms/src/lib_tests.rs
+++ b/crates/developer_platforms/src/lib_tests.rs
@@ -182,6 +182,24 @@ impl PullRequestProvider for MockApiProvider {
         // Mock implementation - returns empty list
         Ok(vec![])
     }
+
+    async fn get_commit_statuses(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<crate::models::CommitStatus>, Error> {
+        Ok(vec![])
+    }
+
+    async fn find_pull_requests_for_commit(
+        &self,
+        _repo_owner: &str,
+        _repo_name: &str,
+        _commit_sha: &str,
+    ) -> Result<Vec<u64>, Error> {
+        Ok(vec![])
+    }
 }
 
 #[cfg(test)]

--- a/crates/developer_platforms/src/models_tests.rs
+++ b/crates/developer_platforms/src/models_tests.rs
@@ -893,8 +893,7 @@ fn test_commit_status_round_trip_all_fields_populated() {
     };
 
     let json_str = to_string(&original).expect("Failed to serialize CommitStatus");
-    let restored: CommitStatus =
-        from_str(&json_str).expect("Failed to deserialize CommitStatus");
+    let restored: CommitStatus = from_str(&json_str).expect("Failed to deserialize CommitStatus");
 
     assert_eq!(restored.context, "renovate/stability-days");
     assert_eq!(restored.state, "success");
@@ -925,8 +924,7 @@ fn test_commit_status_round_trip_description_null() {
         parsed["description"]
     );
 
-    let restored: CommitStatus =
-        from_str(&json_str).expect("Failed to deserialize CommitStatus");
+    let restored: CommitStatus = from_str(&json_str).expect("Failed to deserialize CommitStatus");
     assert_eq!(restored.description, None);
 }
 
@@ -961,8 +959,7 @@ fn test_commit_status_state_pending_round_trips() {
     };
 
     let json_str = to_string(&status).expect("Failed to serialize CommitStatus");
-    let restored: CommitStatus =
-        from_str(&json_str).expect("Failed to deserialize CommitStatus");
+    let restored: CommitStatus = from_str(&json_str).expect("Failed to deserialize CommitStatus");
 
     assert_eq!(restored.state, "pending");
 }
@@ -977,8 +974,7 @@ fn test_commit_status_state_success_round_trips() {
     };
 
     let json_str = to_string(&status).expect("Failed to serialize CommitStatus");
-    let restored: CommitStatus =
-        from_str(&json_str).expect("Failed to deserialize CommitStatus");
+    let restored: CommitStatus = from_str(&json_str).expect("Failed to deserialize CommitStatus");
 
     assert_eq!(restored.state, "success");
 }
@@ -993,8 +989,7 @@ fn test_commit_status_state_failure_round_trips() {
     };
 
     let json_str = to_string(&status).expect("Failed to serialize CommitStatus");
-    let restored: CommitStatus =
-        from_str(&json_str).expect("Failed to deserialize CommitStatus");
+    let restored: CommitStatus = from_str(&json_str).expect("Failed to deserialize CommitStatus");
 
     assert_eq!(restored.state, "failure");
 }
@@ -1009,8 +1004,7 @@ fn test_commit_status_state_error_round_trips() {
     };
 
     let json_str = to_string(&status).expect("Failed to serialize CommitStatus");
-    let restored: CommitStatus =
-        from_str(&json_str).expect("Failed to deserialize CommitStatus");
+    let restored: CommitStatus = from_str(&json_str).expect("Failed to deserialize CommitStatus");
 
     assert_eq!(restored.state, "error");
 }
@@ -1090,8 +1084,7 @@ fn test_commit_status_json_field_names_match_github_api_contract() {
     };
 
     let json_str = to_string(&status).expect("Failed to serialize CommitStatus");
-    let parsed: serde_json::Value =
-        serde_json::from_str(&json_str).expect("Failed to parse JSON");
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("Failed to parse JSON");
 
     assert!(
         parsed.get("context").is_some(),
@@ -1121,8 +1114,7 @@ fn test_commit_status_context_field_with_slashes_and_dots_preserved() {
     };
 
     let json_str = to_string(&status).expect("Failed to serialize CommitStatus");
-    let restored: CommitStatus =
-        from_str(&json_str).expect("Failed to deserialize CommitStatus");
+    let restored: CommitStatus = from_str(&json_str).expect("Failed to deserialize CommitStatus");
 
     assert_eq!(restored.context, original_context);
 }
@@ -1140,8 +1132,7 @@ fn test_commit_status_description_some_value_round_trips_correctly() {
     };
 
     let json_str = to_string(&original).expect("Failed to serialize CommitStatus");
-    let restored: CommitStatus =
-        from_str(&json_str).expect("Failed to deserialize CommitStatus");
+    let restored: CommitStatus = from_str(&json_str).expect("Failed to deserialize CommitStatus");
 
     assert!(
         restored.description.is_some(),

--- a/crates/server/src/webhook.rs
+++ b/crates/server/src/webhook.rs
@@ -28,6 +28,7 @@ use merge_warden_core::{
     MergeWarden,
 };
 use merge_warden_developer_platforms::github::GitHubProvider;
+use merge_warden_developer_platforms::PullRequestProvider as _;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -293,6 +294,161 @@ impl MergeWardenWebhookHandler {
 
         Ok(())
     }
+
+    /// Processes a `status` webhook event.
+    ///
+    /// When a commit status changes (e.g. `renovate/stability-days` transitions
+    /// from `pending` → `success`), GitHub fires a `status` event. This handler:
+    ///
+    /// 1. Ignores events whose `context` is not `renovate/stability-days`.
+    /// 2. Resolves the installation client from the payload `installation.id`.
+    /// 3. Calls [`merge_warden_developer_platforms::PullRequestProvider::find_pull_requests_for_commit`]
+    ///    to discover all open PRs whose HEAD points at the updated SHA.
+    /// 4. For each PR, loads its config and re-runs
+    ///    [`MergeWarden::process_pull_request`] so the stability label is
+    ///    applied or removed as appropriate.
+    ///
+    /// Errors for individual PRs are logged at `warn` and do not abort
+    /// processing of remaining PRs.
+    pub async fn handle_status_event(
+        &self,
+        envelope: &EventEnvelope,
+    ) -> Result<(), ServerError> {
+        let payload = envelope.payload.raw();
+
+        let context = payload["context"].as_str().unwrap_or("");
+        if context != merge_warden_core::config::RENOVATE_STABILITY_CHECK_CONTEXT {
+            debug!(
+                context = %context,
+                "Ignoring status event with non-renovate context"
+            );
+            return Ok(());
+        }
+
+        let sha = match payload["sha"].as_str() {
+            Some(s) => s.to_string(),
+            None => {
+                error!("Status event payload missing 'sha' field");
+                return Err(ServerError::ProcessingError(
+                    "Missing sha in status payload".to_string(),
+                ));
+            }
+        };
+
+        let installation_id = match payload["installation"]["id"].as_u64() {
+            Some(id) => id,
+            None => {
+                error!("Status event payload missing 'installation.id' field");
+                return Err(ServerError::ProcessingError(
+                    "Missing installation ID in status payload".to_string(),
+                ));
+            }
+        };
+
+        let repo_owner = &envelope.repository.owner.login;
+        let repo_name = &envelope.repository.name;
+
+        info!(
+            repository_owner = repo_owner.as_str(),
+            repository = repo_name.as_str(),
+            sha = %sha,
+            context = %context,
+            "Processing renovate stability status event"
+        );
+
+        let installation_client = self
+            .github_client
+            .installation_by_id(InstallationId::new(installation_id))
+            .await
+            .map_err(|e| {
+                error!(error = %e, "Failed to create installation client for status event");
+                ServerError::AuthError(format!("Failed to create installation client: {e}"))
+            })?;
+
+        let provider = GitHubProvider::new(installation_client);
+
+        let pr_numbers = provider
+            .find_pull_requests_for_commit(repo_owner, repo_name, &sha)
+            .await
+            .map_err(|e| {
+                error!(error = %e, "Failed to find PRs for commit SHA");
+                ServerError::ProcessingError(format!("Failed to find PRs for commit: {e}"))
+            })?;
+
+        if pr_numbers.is_empty() {
+            debug!(
+                repository_owner = repo_owner.as_str(),
+                repository = repo_name.as_str(),
+                sha = %sha,
+                "No open PRs found for commit SHA — nothing to do"
+            );
+            return Ok(());
+        }
+
+        let merge_warden_config_path = ".github/merge-warden.toml";
+
+        for pr_number in pr_numbers {
+            let issue_provider = provider.clone();
+
+            let validation_config = match resolve_pull_request_config(
+                repo_owner,
+                repo_name,
+                merge_warden_config_path,
+                &provider,
+                &self.policies,
+                Some(&provider),
+            )
+            .await
+            {
+                Ok(config) => config,
+                Err(ConfigLoadError::OrgPolicyUnavailable(ref msg)) => {
+                    warn!(
+                        repository_owner = repo_owner.as_str(),
+                        repository = repo_name.as_str(),
+                        pull_request = pr_number,
+                        org_policy_error = msg.as_str(),
+                        "Org policy unreachable for PR during status event processing; using defaults"
+                    );
+                    CurrentPullRequestValidationConfiguration::from_app_defaults(&self.policies)
+                }
+                Err(e) => {
+                    warn!(
+                        repository_owner = repo_owner.as_str(),
+                        repository = repo_name.as_str(),
+                        pull_request = pr_number,
+                        error = %e,
+                        "Failed to resolve config for PR during status event; using defaults"
+                    );
+                    CurrentPullRequestValidationConfiguration::from_app_defaults(&self.policies)
+                }
+            };
+
+            let warden = MergeWarden::with_config(provider.clone(), validation_config)
+                .with_issue_provider(Box::new(issue_provider));
+
+            if let Err(e) = warden
+                .process_pull_request(repo_owner, repo_name, pr_number)
+                .await
+            {
+                warn!(
+                    repository_owner = repo_owner.as_str(),
+                    repository = repo_name.as_str(),
+                    pull_request = pr_number,
+                    error = %e,
+                    "Failed to process PR during status event"
+                );
+            } else {
+                info!(
+                    repository_owner = repo_owner.as_str(),
+                    repository = repo_name.as_str(),
+                    pull_request = pr_number,
+                    "PR re-evaluated after renovate stability status change"
+                );
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -301,6 +457,13 @@ impl WebhookHandler for MergeWardenWebhookHandler {
         &self,
         envelope: &EventEnvelope,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if envelope.event_type == "status" {
+            return self
+                .handle_status_event(envelope)
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>);
+        }
+
         if envelope.event_type != "pull_request" && envelope.event_type != "pull_request_review" {
             debug!(event_type = %envelope.event_type, "Ignoring non-pull-request event");
             return Ok(());

--- a/crates/server/src/webhook.rs
+++ b/crates/server/src/webhook.rs
@@ -310,10 +310,7 @@ impl MergeWardenWebhookHandler {
     ///
     /// Errors for individual PRs are logged at `warn` and do not abort
     /// processing of remaining PRs.
-    pub async fn handle_status_event(
-        &self,
-        envelope: &EventEnvelope,
-    ) -> Result<(), ServerError> {
+    pub async fn handle_status_event(&self, envelope: &EventEnvelope) -> Result<(), ServerError> {
         let payload = envelope.payload.raw();
 
         let context = payload["context"].as_str().unwrap_or("");
@@ -387,43 +384,44 @@ impl MergeWardenWebhookHandler {
 
         let merge_warden_config_path = ".github/merge-warden.toml";
 
+        // All PRs in the loop share the same repository, so the config is
+        // identical for each.  Load it once before entering the loop to avoid
+        // redundant API calls (including the org-policy fetch).
+        let validation_config = match resolve_pull_request_config(
+            repo_owner,
+            repo_name,
+            merge_warden_config_path,
+            &provider,
+            &self.policies,
+            Some(&provider),
+        )
+        .await
+        {
+            Ok(config) => config,
+            Err(ConfigLoadError::OrgPolicyUnavailable(ref msg)) => {
+                warn!(
+                    repository_owner = repo_owner.as_str(),
+                    repository = repo_name.as_str(),
+                    org_policy_error = msg.as_str(),
+                    "Org policy unreachable during status event processing; using defaults"
+                );
+                CurrentPullRequestValidationConfiguration::from_app_defaults(&self.policies)
+            }
+            Err(e) => {
+                warn!(
+                    repository_owner = repo_owner.as_str(),
+                    repository = repo_name.as_str(),
+                    error = %e,
+                    "Failed to resolve config during status event; using defaults"
+                );
+                CurrentPullRequestValidationConfiguration::from_app_defaults(&self.policies)
+            }
+        };
+
         for pr_number in pr_numbers {
             let issue_provider = provider.clone();
 
-            let validation_config = match resolve_pull_request_config(
-                repo_owner,
-                repo_name,
-                merge_warden_config_path,
-                &provider,
-                &self.policies,
-                Some(&provider),
-            )
-            .await
-            {
-                Ok(config) => config,
-                Err(ConfigLoadError::OrgPolicyUnavailable(ref msg)) => {
-                    warn!(
-                        repository_owner = repo_owner.as_str(),
-                        repository = repo_name.as_str(),
-                        pull_request = pr_number,
-                        org_policy_error = msg.as_str(),
-                        "Org policy unreachable for PR during status event processing; using defaults"
-                    );
-                    CurrentPullRequestValidationConfiguration::from_app_defaults(&self.policies)
-                }
-                Err(e) => {
-                    warn!(
-                        repository_owner = repo_owner.as_str(),
-                        repository = repo_name.as_str(),
-                        pull_request = pr_number,
-                        error = %e,
-                        "Failed to resolve config for PR during status event; using defaults"
-                    );
-                    CurrentPullRequestValidationConfiguration::from_app_defaults(&self.policies)
-                }
-            };
-
-            let warden = MergeWarden::with_config(provider.clone(), validation_config)
+            let warden = MergeWarden::with_config(provider.clone(), validation_config.clone())
                 .with_issue_provider(Box::new(issue_provider));
 
             if let Err(e) = warden

--- a/crates/server/src/webhook_tests.rs
+++ b/crates/server/src/webhook_tests.rs
@@ -2,7 +2,7 @@ use axum::{http::StatusCode, response::IntoResponse};
 use chrono::Utc;
 use github_bot_sdk::{
     client::{ClientConfig, GitHubClient, OwnerType, Repository, RepositoryOwner},
-    events::{EventPayload, EventEnvelope},
+    events::{EventEnvelope, EventPayload},
     webhook::WebhookHandler,
 };
 use merge_warden_core::config::ApplicationDefaults;

--- a/crates/server/src/webhook_tests.rs
+++ b/crates/server/src/webhook_tests.rs
@@ -1,6 +1,67 @@
 use axum::{http::StatusCode, response::IntoResponse};
+use chrono::Utc;
+use github_bot_sdk::{
+    client::{ClientConfig, GitHubClient, OwnerType, Repository, RepositoryOwner},
+    events::{EventPayload, EventEnvelope},
+    webhook::WebhookHandler,
+};
+use merge_warden_core::config::ApplicationDefaults;
+use merge_warden_developer_platforms::app_auth::AppAuthProvider;
+use serde_json::json;
 
 use super::health_check;
+use super::MergeWardenWebhookHandler;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// RSA private key used only in tests.  Generated offline; never used in
+/// production.  Must be a valid PEM-encoded PKCS#8 or traditional RSA key so
+/// `AppAuthProvider` can parse it.
+const TEST_PEM: &str = include_str!("../../developer_platforms/testdata/test-rsa-key.pem");
+
+fn make_test_handler() -> MergeWardenWebhookHandler {
+    let auth = AppAuthProvider::new(12345, TEST_PEM, "https://api.github.com")
+        .expect("test RSA key must be valid");
+    let github_client = GitHubClient::builder(auth)
+        .config(ClientConfig::default())
+        .build()
+        .expect("GitHub client must build");
+    MergeWardenWebhookHandler::new(github_client, ApplicationDefaults::default())
+}
+
+fn make_status_envelope(context: &str) -> EventEnvelope {
+    let repo = Repository {
+        id: 1,
+        name: "test-repo".to_string(),
+        full_name: "owner/test-repo".to_string(),
+        owner: RepositoryOwner {
+            login: "owner".to_string(),
+            id: 1,
+            avatar_url: "https://example.com/avatar.png".to_string(),
+            owner_type: OwnerType::User,
+        },
+        private: false,
+        description: None,
+        default_branch: "main".to_string(),
+        html_url: "https://github.com/owner/test-repo".to_string(),
+        clone_url: "https://github.com/owner/test-repo.git".to_string(),
+        ssh_url: "git@github.com:owner/test-repo.git".to_string(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    EventEnvelope::new(
+        "status".to_string(),
+        repo,
+        EventPayload::new(json!({
+            "context": context,
+            "sha": "deadbeef",
+            "state": "pending",
+            "installation": { "id": 99 }
+        })),
+    )
+}
 
 // ---------------------------------------------------------------------------
 // health_check
@@ -10,4 +71,45 @@ use super::health_check;
 async fn health_check_returns_200_ok() {
     let response = health_check().await.into_response();
     assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ---------------------------------------------------------------------------
+// handle_status_event
+// ---------------------------------------------------------------------------
+
+/// A status event whose context is NOT `renovate/stability-days` must be
+/// silently ignored — no API calls, no errors.
+#[tokio::test]
+async fn handle_status_event_ignores_non_renovate_context() {
+    let handler = make_test_handler();
+    let envelope = make_status_envelope("ci/build");
+
+    let result = handler.handle_status_event(&envelope).await;
+
+    assert!(
+        result.is_ok(),
+        "non-renovate status event should be ignored: {:?}",
+        result
+    );
+}
+
+// ---------------------------------------------------------------------------
+// handle_event routing
+// ---------------------------------------------------------------------------
+
+/// A `status` event must be dispatched to `handle_status_event`.
+/// Using a non-renovate context means no GitHub API calls are made, so the
+/// handler returns Ok(()) without a live network connection.
+#[tokio::test]
+async fn handle_event_routes_status_events() {
+    let handler = make_test_handler();
+    let envelope = make_status_envelope("ci/build");
+
+    let result = handler.handle_event(&envelope).await;
+
+    assert!(
+        result.is_ok(),
+        "status event should be routed and return Ok(()): {:?}",
+        result
+    );
 }


### PR DESCRIPTION
## Summary

Implements FR008 — Renovate Stability Label Management. When Renovate creates a PR and a stability period is configured, a `status` event fires on each commit SHA change. This PR wires up the full pipeline from webhook ingestion to label application/removal.

## Changes

### `developer_platforms` crate

- **`PullRequestProvider` trait**: new `create_label` method with a no-op default implementation (fully backwards-compatible)
- **`GitHubProvider`**: implements `create_label` via `LabelsClient::create`, plus `get_commit_statuses` and `find_pull_requests_for_commit`
- **`RenovateStabilityConfig`**: added to `ApplicationDefaults` with merge semantics

### `core` crate — labels

- **`manage_renovate_stability_label`**: fetches commit statuses for the PR HEAD SHA, finds the first `renovate/stability-days` context entry, then:
  - `pending / error / failure` → ensures the label exists in the repo (creates if absent with color `#986ee2`), then applies it to the PR
  - `success` → removes the label; 404 treated as no-op (idempotent)
  - No matching context or `config.enabled = false` → no-op
- 9 unit tests via `StabilityMockProvider`

### \core\ crate — lib

- **`MergeWarden::communicate_renovate_stability_status`**: best-effort wrapper — errors logged at `warn`, never propagated
- **`process_pull_request`**: calls `communicate_renovate_stability_status` after `communicate_pr_state_labels` on every event (including drafts)
- 7 integration tests; `DynamicMockGitProvider` extended with configurable `commit_statuses`

### `server` crate — webhook

- **`handle_status_event`**: new handler — ignores non-`renovate/stability-days` contexts; resolves installation client; calls `find_pull_requests_for_commit`; re-runs `process_pull_request` per PR (errors logged at `warn`, processing continues)
- **`handle_event`**: routes `status` events before existing `pull_request` / `pull_request_review` check
- 2 new webhook tests

## Test results

All 1,074 tests pass across the workspace (`cargo test --workspace`).