### PR TITLE
docs: fill gaps in user documentation

### DIFF
--- a/docs/user/explanation/config-precedence.md
+++ b/docs/user/explanation/config-precedence.md
@@ -5,19 +5,29 @@ description: "How compiled-in defaults, application config, and per-repository c
 
 # Configuration precedence
 
-Merge Warden resolves settings from three layers. Higher layers override lower ones.
+Merge Warden resolves settings from up to four layers. Higher layers override lower ones.
 
 ```
-Per-repository .github/merge-warden.toml    ← highest priority
+Per-repository .github/merge-warden.toml    ← highest priority (repo can override org defaults)
+        ↓  overrides
+Org-level policy [defaults] section          ← org defaults (overridable by repo)
+        ↑
+        │  (per-repo config sits between org defaults and org enforced)
+        ↓
+Org-level policy [enforced] section          ← org enforced (cannot be overridden by repo)
         ↓  overrides
 MERGE_WARDEN_CONFIG_FILE (application defaults)
         ↓  overrides
 Compiled-in defaults                         ← lowest priority
 ```
 
+The org-level policy tier is optional. When `[org_policy_source]` is not configured in
+the application config, the system uses the three-tier model (application defaults →
+per-repository config → compiled-in defaults).
+
 ---
 
-## The three layers
+## The four layers
 
 ### Layer 1 — Compiled-in defaults
 
@@ -39,13 +49,29 @@ without forcing every repository to maintain its own config file.
 See [Application configuration schema](../reference/app-config.md) and
 [Set application-level defaults](../how-to/set-app-level-defaults.md).
 
-### Layer 3 — Per-repository config (`.github/merge-warden.toml`)
+### Layer 3 — Org-level policy (optional)
+
+When `[org_policy_source]` is configured in the application-level config, the server
+fetches a central org policy TOML file on every PR event. This file has two sections:
+
+- **`[defaults]`** — org-wide defaults that individual repositories *can* override with
+  their own `.github/merge-warden.toml`. Sits between the application defaults and the
+  per-repo config in the resolution chain.
+- **`[enforced]`** — policies that *cannot* be overridden by per-repo config. Sits above
+  the per-repo config in the chain.
+
+Org policies also support `[[conditional_policies]]` blocks that apply only to repositories
+matching specific topic or custom-property conditions.
+
+See [Configure an organisation-level policy](../how-to/configure-org-policy.md).
+
+### Layer 4 — Per-repository config (`.github/merge-warden.toml`)
 
 A TOML file committed to the default branch of each repository. It controls policies for
 that repository only.
 
-When present, it overrides the corresponding fields from the application-level config.
-Fields not specified in the per-repo file continue to use the application-level value.
+When present, it overrides the corresponding fields from the application-level config and
+any org-level defaults. It cannot override fields set in the org-level `[enforced]` section.
 
 See [Per-repository configuration schema](../reference/per-repo-config.md).
 
@@ -58,11 +84,13 @@ set in the application config but `.github/merge-warden.toml` does not include a
 `[policies.pullRequests.prTitle]` section, the application-level setting applies.
 
 If `.github/merge-warden.toml` does include that section and sets `required = false`, the
-per-repo value overrides the application-level value for that field.
+per-repo value overrides the application-level value for that field — unless the org-level
+`[enforced]` section has already set `required = true` for that field, in which case the
+enforced value wins.
 
 ---
 
-## Example
+## Example (three-tier, no org policy)
 
 Assume the application config sets:
 
@@ -101,5 +129,6 @@ defaults, no checks fail and no labels are applied.
 ## Related
 
 - [Why there are two configuration files](two-config-files.md)
+- [Configure an organisation-level policy](../how-to/configure-org-policy.md)
 - [Application configuration schema](../reference/app-config.md)
 - [Per-repository configuration schema](../reference/per-repo-config.md)

--- a/docs/user/explanation/config-precedence.md
+++ b/docs/user/explanation/config-precedence.md
@@ -8,7 +8,7 @@ description: "How compiled-in defaults, application config, and per-repository c
 Merge Warden resolves settings from up to four layers. Higher layers override lower ones.
 
 ```
-Per-repository .github/merge-warden.toml    ← highest priority (repo can override org defaults)
+Per-repository .github/merge-warden.toml    ← highest per-repo priority (overrides org defaults, not org enforced)
         ↓  overrides
 Org-level policy [defaults] section          ← org defaults (overridable by repo)
         ↑

--- a/docs/user/explanation/how-merge-warden-works.md
+++ b/docs/user/explanation/how-merge-warden-works.md
@@ -109,6 +109,22 @@ Requests with a missing or invalid `X-Hub-Signature-256` header are rejected wit
 
 ---
 
+## Automatic configuration file validation
+
+When a pull request modifies `.github/merge-warden.toml`, Merge Warden automatically
+fetches the version of that file at the PR's head commit and validates it.
+
+- If the file is **invalid** (bad TOML or an unsupported `schemaVersion`), Merge Warden
+  posts a warning comment on the PR describing the errors. This comment is updated on every
+  subsequent push to the PR branch.
+- If the file is **valid**, any existing warning comment is automatically deleted.
+
+This validation is purely informational — it does not affect the Merge Warden check result
+and cannot block merging. Its purpose is to give contributors early feedback before a
+broken config lands on the default branch.
+
+---
+
 ## What Merge Warden does not do
 
 - It does not merge or close pull requests.

--- a/docs/user/how-to/configure-change-type-labels.md
+++ b/docs/user/how-to/configure-change-type-labels.md
@@ -106,7 +106,41 @@ All three are enabled by default. Disable any strategy by setting it to `false`.
 
 ---
 
+## Keyword-triggered labels
+
+In addition to commit-type labels, Merge Warden can apply labels based on keywords found
+anywhere in the PR title or body. These are configured under
+`[change_type_labels.keyword_labels]` and work independently of the commit-type prefix.
+
+| Keyword trigger | Default label |
+| :--- | :--- |
+| `!:` in title, or `breaking change` / `breaking-change` in body | `breaking-change` |
+| `security` or `vulnerability` in body | `security` |
+| `hotfix` in body | `hotfix` |
+| `tech debt` / `technical debt` in body | `tech-debt` |
+
+To use different label names:
+
+```toml
+[change_type_labels]
+enabled = true
+
+[change_type_labels.keyword_labels]
+breaking_change = "semver: breaking"
+security        = "sec: vulnerability"
+hotfix          = "priority: hotfix"
+tech_debt       = "quality: tech-debt"
+```
+
+When a keyword label is applied, Merge Warden posts a comment on the PR explaining which
+keyword triggered it and showing the command to suppress it. See
+[Suppress keyword-triggered labels](configure-label-suppression.md).
+
+---
+
 ## Related
 
-- [Full per-repo config schema](../reference/per-repo-config.md#change_type_labels)
+- [Full per-repo config schema — keyword_labels](../reference/per-repo-config.md#change_type_labelskeyword_labels)
+- [Full per-repo config schema — change_type_labels](../reference/per-repo-config.md#change_type_labels)
+- [Suppress keyword-triggered labels](configure-label-suppression.md)
 - [Configure PR title validation](configure-pr-title-validation.md)

--- a/docs/user/how-to/configure-label-suppression.md
+++ b/docs/user/how-to/configure-label-suppression.md
@@ -1,0 +1,97 @@
+---
+title: "How to suppress keyword-triggered labels"
+description: "Allow PR authors and reviewers to prevent Merge Warden from re-applying keyword-triggered labels."
+---
+
+# How to suppress keyword-triggered labels
+
+When Merge Warden detects a keyword in a PR title or body (such as `breaking change`,
+`security`, `hotfix`, or `tech debt`), it automatically applies a label and posts an
+explanatory comment. If the label was incorrectly triggered — for example, the word
+"security" appears in a comment that does not indicate a security concern — a PR
+participant can suppress it.
+
+---
+
+## Posting a suppression command
+
+Any PR participant (author, reviewer, or commenter) can suppress a keyword-triggered
+label by posting a PR comment that contains the following line:
+
+```
+@merge-warden suppress: <label-name>
+```
+
+Replace `<label-name>` with the exact name of the label to suppress.
+
+**Example:**
+
+If the `breaking-change` label was incorrectly applied, post:
+
+```
+@merge-warden suppress: breaking-change
+```
+
+Merge Warden processes suppression commands on the next PR event (for example, when
+a new commit is pushed or when the PR title is edited). After a suppression command
+is detected:
+
+- The label is removed from the PR.
+- Merge Warden will not re-apply that label for the lifetime of the PR, even if
+  subsequent evaluations detect the keyword again.
+
+---
+
+## How the explanatory comment helps
+
+When Merge Warden applies a keyword-triggered label, it posts a comment on the PR that
+includes the exact suppression command to use. You do not need to remember the syntax —
+look for the comment that mentions the label name.
+
+---
+
+## Which labels can be suppressed
+
+Any keyword-triggered label can be suppressed. The four built-in keyword labels and
+their default names are:
+
+| Keyword trigger | Default label name |
+| :--- | :--- |
+| `!:` in title, or `breaking change` in body | `breaking-change` |
+| `security` or `vulnerability` in body | `security` |
+| `hotfix` in body | `hotfix` |
+| `tech debt` or `technical debt` in body | `tech-debt` |
+
+If you have customised label names using `[change_type_labels.keyword_labels]`, use the
+customised names in the suppression command.
+
+Suppression affects only keyword-triggered labels. Labels applied by other features
+(PR size, WIP, state lifecycle, change-type) cannot be suppressed via this mechanism.
+
+---
+
+## Changing the bot mention prefix
+
+By default the suppression command prefix is `@merge-warden`. If your GitHub App is
+installed under a different name, set the `bot_mention` field in the application-level
+configuration:
+
+```toml
+# In the application-level config file (MERGE_WARDEN_CONFIG_FILE)
+[policies]
+bot_mention = "@acme-merge-warden[bot]"
+```
+
+Users must then use the new prefix in their suppression commands:
+
+```
+@acme-merge-warden[bot] suppress: breaking-change
+```
+
+---
+
+## Related
+
+- [Configure change-type labels](configure-change-type-labels.md)
+- [Application configuration schema — bot_mention field](../reference/app-config.md#bot_mention)
+- [Per-repository configuration schema — keyword_labels](../reference/per-repo-config.md#change_type_labelskeyword_labels)

--- a/docs/user/how-to/configure-label-suppression.md
+++ b/docs/user/how-to/configure-label-suppression.md
@@ -16,13 +16,15 @@ participant can suppress it.
 ## Posting a suppression command
 
 Any PR participant (author, reviewer, or commenter) can suppress a keyword-triggered
-label by posting a PR comment that contains the following line:
+label by posting a PR comment that contains the following on its own line:
 
 ```
 @merge-warden suppress: <label-name>
 ```
 
-Replace `<label-name>` with the exact name of the label to suppress.
+Replace `<label-name>` with the exact name of the label to suppress. The command can
+appear anywhere in a comment body (it does not need to be the only content), but it must
+start at the beginning of a line. Leading and trailing whitespace on that line is ignored.
 
 **Example:**
 

--- a/docs/user/how-to/configure-org-policy.md
+++ b/docs/user/how-to/configure-org-policy.md
@@ -9,21 +9,15 @@ An organisation-level policy file lets a platform team define PR policies in one
 place and have them applied to every repository the Merge Warden server processes — without
 each repository needing to maintain a `.github/merge-warden.toml`.
 
-The org policy adds a fourth tier to the configuration resolution chain:
+The org policy adds a fourth tier to the configuration resolution chain (1 = highest priority):
 
-```
-Per-repository .github/merge-warden.toml    (highest priority)
-        ↓  overrides
-Org-enforced policies                        (cannot be overridden by per-repo config)
-        ↓
-Per-repository .github/merge-warden.toml    (sits between org defaults and org enforced)
-        ↓  overrides
-Org-default policies                         (can be overridden by per-repo config)
-        ↓  overrides
-MERGE_WARDEN_CONFIG_FILE (application defaults)
-        ↓  overrides
-Compiled-in defaults                         (lowest priority)
-```
+| Priority | Source | Overridable? |
+| :---: | :--- | :--- |
+| 1 | Org-enforced policies — `[enforced]` section | No — beats everything below |
+| 2 | Per-repository `.github/merge-warden.toml` | — |
+| 3 | Org-default policies — `[defaults]` section | Yes — per-repo config overrides these |
+| 4 | Application defaults — `MERGE_WARDEN_CONFIG_FILE` | Yes |
+| 5 (lowest) | Compiled-in defaults | Yes |
 
 ---
 
@@ -80,8 +74,12 @@ path  = "merge-warden/org-policy.toml"
 ```
 
 The server fetches the org policy file on every PR event using the same GitHub App
-credentials configured for the server instance. The App must have `Contents: Read`
-permission on the policy repository.
+credentials configured for the server instance.
+
+> **Required permission:** The GitHub App must have **`Contents: Read`** permission
+> on the policy repository. Without it, every fetch will fail and PR processing will
+> either be aborted (if `fail_if_unreachable = true`) or degrade to three-tier
+> resolution (the default).
 
 ---
 

--- a/docs/user/how-to/configure-org-policy.md
+++ b/docs/user/how-to/configure-org-policy.md
@@ -1,0 +1,156 @@
+---
+title: "How to configure an organisation-level policy"
+description: "Store shared PR policies in a central repository and enforce them across all repositories."
+---
+
+# How to configure an organisation-level policy
+
+An organisation-level policy file lets a platform team define PR policies in one central
+place and have them applied to every repository the Merge Warden server processes — without
+each repository needing to maintain a `.github/merge-warden.toml`.
+
+The org policy adds a fourth tier to the configuration resolution chain:
+
+```
+Per-repository .github/merge-warden.toml    (highest priority)
+        ↓  overrides
+Org-enforced policies                        (cannot be overridden by per-repo config)
+        ↓
+Per-repository .github/merge-warden.toml    (sits between org defaults and org enforced)
+        ↓  overrides
+Org-default policies                         (can be overridden by per-repo config)
+        ↓  overrides
+MERGE_WARDEN_CONFIG_FILE (application defaults)
+        ↓  overrides
+Compiled-in defaults                         (lowest priority)
+```
+
+---
+
+## Step 1: Create the org policy repository
+
+Create (or designate) a repository in your organisation to hold the policy file. The
+repository must be accessible to the GitHub App installation.
+
+A common convention is a repository named `platform-configs` or `.github`.
+
+---
+
+## Step 2: Create the org policy file
+
+Create a file in the policy repository. Any path works; `merge-warden/org-policy.toml`
+is a readable convention.
+
+The file must begin with `schemaVersion = 1` and may include an `[enforced]` section,
+a `[defaults]` section, and any number of `[[conditional_policies]]` blocks.
+
+### Minimal example
+
+```toml
+schemaVersion = 1
+
+# Settings that CANNOT be overridden by per-repo config.
+[enforced.policies.pullRequests.prTitle]
+required = true
+label_if_missing = "pr-issue: invalid-title-format"
+```
+
+### Full example
+
+See
+[`samples/merge-warden-org-policy.sample.toml`](https://github.com/pvandervelde/merge_warden/blob/master/samples/merge-warden-org-policy.sample.toml)
+for an annotated example covering enforced, default, and conditional policy sections.
+
+---
+
+## Step 3: Point the server at the org policy file
+
+Add `[org_policy_source]` to the application-level configuration file
+(`MERGE_WARDEN_CONFIG_FILE`):
+
+```toml
+[org_policy_source]
+owner = "my-org"
+repo  = "platform-configs"
+path  = "merge-warden/org-policy.toml"
+
+# Optional — set to true to fail PR processing if the policy file is unreachable.
+# Default: false (degrade gracefully to three-tier resolution when unreachable).
+# fail_if_unreachable = false
+```
+
+The server fetches the org policy file on every PR event using the same GitHub App
+credentials configured for the server instance. The App must have `Contents: Read`
+permission on the policy repository.
+
+---
+
+## Enforced vs default sections
+
+| Section | When to use | Can be overridden by per-repo config? |
+| :--- | :--- | :--- |
+| `[enforced.*]` | Non-negotiable requirements | No — org enforced beats per-repo config |
+| `[defaults.*]` | Sensible org defaults | Yes — per-repo config can override them |
+
+Use the `[enforced]` section for compliance requirements that must hold regardless of
+what individual teams want. Use `[defaults]` for policies that most teams should follow
+but that individual teams may need to adjust.
+
+---
+
+## Conditional policies
+
+A `[[conditional_policies]]` block applies only to repositories that match its condition.
+Conditions evaluate against repository **topics** and **custom properties**.
+
+```toml
+[[conditional_policies]]
+[conditional_policies.condition]
+# Applies to any repository with the "payments" or "finance" topic.
+has_any_topic = ["payments", "finance"]
+
+[conditional_policies.enforced.policies.pullRequests.prTitle]
+required = true
+pattern = "^PAY-[0-9]+: .+"
+label_if_missing = "pr-issue: invalid-title-format"
+```
+
+### Condition semantics
+
+| Criterion | Match logic |
+| :--- | :--- |
+| `has_any_topic` | At least one listed topic must be present (OR, case-insensitive) |
+| `has_custom_property` | All listed key-value pairs must be present (AND, values case-sensitive) |
+| Both criteria together | Both must match simultaneously (AND) |
+| Empty condition | Matches every repository |
+
+### Custom properties
+
+Custom properties require a GitHub Enterprise plan and the
+`org_custom_property: read` permission on the GitHub App. On non-enterprise GitHub
+plans the custom properties API returns a 403/404 response; Merge Warden treats this as
+an empty map and evaluates topic conditions normally.
+
+---
+
+## Behaviour when the org policy file is unreachable
+
+| `fail_if_unreachable` | File status | Behaviour |
+| :--- | :--- | :--- |
+| `false` (default) | Fetch error or parse error | Warn and fall back to three-tier resolution |
+| `false` (default) | File does not exist (`404`) | Warn and fall back to three-tier resolution |
+| `true` | Fetch error or parse error | Return an error; PR processing aborted |
+| `true` | File does not exist (`404`) | Warn and fall back (file absence is always a graceful fallback) |
+
+The rationale for the `404` exception: a missing file is the expected bootstrap state
+when the policy file has not yet been created. A fetch error, by contrast, indicates an
+infrastructure problem that the operator may want to surface explicitly.
+
+---
+
+## Related
+
+- [Application configuration schema — org_policy_source](../reference/app-config.md#org_policy_source)
+- [Configuration precedence](../explanation/config-precedence.md)
+- [Set application-level policy defaults](set-app-level-defaults.md)
+- [Per-repository configuration schema](../reference/per-repo-config.md)

--- a/docs/user/how-to/configure-renovate-stability.md
+++ b/docs/user/how-to/configure-renovate-stability.md
@@ -42,9 +42,24 @@ No configuration file entry is required. The defaults are:
 
 ## Disabling the feature
 
-Renovate stability label management can only be disabled at the **application level**
-(`MERGE_WARDEN_CONFIG_FILE`). Setting `enabled = false` at the application level prevents
-it from being activated by per-repo config.
+The merge rule for `enabled` is OR: the feature is active when **either** the
+application tier or the per-repo tier has `enabled = true`. Because the per-repo
+`[policies.pullRequests.renovateStability]` section defaults to `enabled = true`, any
+repository that has a `.github/merge-warden.toml` file (even one that does not mention
+Renovate stability at all) will keep the feature enabled regardless of the
+application-level setting.
+
+To fully disable the feature for a repository, set `enabled = false` explicitly in
+that repository's `.github/merge-warden.toml`:
+
+```toml
+# In .github/merge-warden.toml (per-repo)
+[policies.pullRequests.renovateStability]
+enabled = false
+```
+
+To disable the feature as the **application-level default** (affecting only repositories
+that have no `.github/merge-warden.toml` at all), set it in `MERGE_WARDEN_CONFIG_FILE`:
 
 ```toml
 # In the application-level config file (MERGE_WARDEN_CONFIG_FILE)
@@ -52,9 +67,10 @@ it from being activated by per-repo config.
 enabled = false
 ```
 
-> **Note:** A per-repo setting of `enabled = false` has no effect if the application
-> level has `enabled = true`. The merge rule is OR: once either tier enables the feature,
-> it stays enabled.
+> **Note:** The application-level `enabled = false` does not suppress the feature for
+> repositories that have their own `.github/merge-warden.toml`, because the per-repo
+> defaults contribute `enabled = true` via the OR merge rule. Repositories that need
+> the feature off must set `enabled = false` in their own config file.
 
 ---
 

--- a/docs/user/how-to/configure-renovate-stability.md
+++ b/docs/user/how-to/configure-renovate-stability.md
@@ -1,0 +1,95 @@
+---
+title: "How to configure Renovate stability labels"
+description: "Track the Renovate stability period for dependency-update PRs with an automatic label."
+---
+
+# How to configure Renovate stability labels
+
+When you use [Renovate](https://docs.renovatebot.com/) to manage dependency updates, Renovate
+can be configured to wait a number of days before auto-merging a new package version (the
+`stabilityDays` setting). Merge Warden integrates with this mechanism by watching for the
+`renovate/stability-days` GitHub commit status and applying a configurable label while the
+wait period has not yet elapsed.
+
+This feature is **enabled by default**. No configuration is required to turn it on.
+
+---
+
+## What the feature does
+
+On every PR event Merge Warden checks whether a commit status named
+`renovate/stability-days` exists on the PR's head commit:
+
+- If the status is `pending`, `error`, or `failure`, the `pending_stability_label` is applied.
+- If the status is `success`, the label is removed.
+- If no such status exists (the PR is not a Renovate PR), nothing happens.
+
+The label is purely informational. It does not affect the Merge Warden check result and
+cannot block merging on its own.
+
+---
+
+## Default configuration
+
+No configuration file entry is required. The defaults are:
+
+| Field | Default |
+| :--- | :--- |
+| `enabled` | `true` |
+| `pending_stability_label` | `"pr-validation: pending-stability"` |
+
+---
+
+## Disabling the feature
+
+Renovate stability label management can only be disabled at the **application level**
+(`MERGE_WARDEN_CONFIG_FILE`). Setting `enabled = false` at the application level prevents
+it from being activated by per-repo config.
+
+```toml
+# In the application-level config file (MERGE_WARDEN_CONFIG_FILE)
+[policies.renovate_stability]
+enabled = false
+```
+
+> **Note:** A per-repo setting of `enabled = false` has no effect if the application
+> level has `enabled = true`. The merge rule is OR: once either tier enables the feature,
+> it stays enabled.
+
+---
+
+## Customising the label name
+
+To use a different label name, add the following to `.github/merge-warden.toml`:
+
+```toml
+schemaVersion = 1
+
+[policies.pullRequests.renovateStability]
+enabled = true
+pending_stability_label = "dependency: awaiting-stability"
+```
+
+Create the label in the repository first (via GitHub repository settings or the API).
+Merge Warden applies labels by name and does not create labels for this feature.
+
+---
+
+## Application-level override
+
+To customise the label globally across all repositories:
+
+```toml
+# In the application-level config file
+[policies.renovate_stability]
+enabled = true
+pending_stability_label = "renovate: stability-pending"
+```
+
+---
+
+## Related
+
+- [Full per-repo config schema](../reference/per-repo-config.md#policiespullrequestsrenovatestability)
+- [Application configuration schema](../reference/app-config.md#policiesrenovate_stability)
+- [Configure PR state lifecycle labels](configure-pr-state-labels.md)

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -44,8 +44,11 @@ size limits, and more.
 - [Configure PR state lifecycle labels](how-to/configure-pr-state-labels.md)
 - [Configure issue metadata propagation](how-to/configure-issue-propagation.md)
 - [Configure change-type labels](how-to/configure-change-type-labels.md)
+- [Configure Renovate stability labels](how-to/configure-renovate-stability.md)
+- [Suppress keyword-triggered labels](how-to/configure-label-suppression.md)
 - [Configure bypass rules](how-to/configure-bypass-rules.md)
 - [Set application-level policy defaults](how-to/set-app-level-defaults.md)
+- [Configure an organisation-level policy](how-to/configure-org-policy.md)
 
 ## Reference
 

--- a/docs/user/reference/app-config.md
+++ b/docs/user/reference/app-config.md
@@ -33,6 +33,26 @@ Top-level policy defaults.
 | `enable_work_item_validation` | bool | `false` | `[workItem] required` |
 | `default_work_item_pattern` | string | *(GitHub issue patterns)* | `[workItem] pattern` |
 | `default_missing_work_item_label` | string | *(none)* | `[workItem] label_if_missing` |
+| `bot_mention` | string | `"@merge-warden"` | *(none — app-level only)* |
+
+### `bot_mention`
+
+The mention prefix that PR participants use to issue bot commands in PR comments.
+The only current command is label suppression:
+
+```
+@merge-warden suppress: <label-name>
+```
+
+If your GitHub App is installed under a different name (for example because you host
+your own fork), set `bot_mention` to match your App's mention handle:
+
+```toml
+[policies]
+bot_mention = "@acme-merge-warden[bot]"
+```
+
+This field has no per-repo equivalent. It is controlled solely by the operator.
 
 ---
 
@@ -84,6 +104,61 @@ for details.
 
 ---
 
+## `[policies.renovate_stability]`
+
+Controls the Renovate stability-days label management feature at the application level.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `enabled` | bool | `true` | When `true`, the `pending_stability_label` is applied to a PR while its `renovate/stability-days` commit status is `pending`, `error`, or `failure`. Removed when the status becomes `success`. |
+| `pending_stability_label` | string | `"pr-validation: pending-stability"` | Name of the label applied during the stability wait period. |
+
+The merge rule for `enabled` is OR: once either the application tier or the per-repo
+tier enables this feature, it stays enabled. To disable for all repositories, set
+`enabled = false` here (individual repos cannot override it back to `false`).
+
+**Example:**
+
+```toml
+[policies.renovate_stability]
+enabled = true
+pending_stability_label = "renovate: stability-pending"
+```
+
+See [Configure Renovate stability labels](../how-to/configure-renovate-stability.md)
+and [Per-repository configuration schema — renovateStability](per-repo-config.md#policiespullrequestsrenovatestability).
+
+---
+
+## `[org_policy_source]`
+
+Optional. When present, the server fetches a central org-level policy TOML file on
+every PR event and inserts it into the configuration resolution chain.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `owner` | string | *(required)* | GitHub organisation or user name that owns the policy repository. |
+| `repo` | string | *(required)* | Name of the repository that holds the org policy file. |
+| `path` | string | *(required)* | Path to the org policy TOML file within the repository, relative to the repository root. |
+| `fail_if_unreachable` | bool | `false` | When `true`, an unreachable or unparseable org policy file causes PR processing to abort with an error. When `false`, failures degrade gracefully to three-tier resolution. A missing file (`404`) always degrades gracefully regardless of this setting. |
+
+**Example:**
+
+```toml
+[org_policy_source]
+owner               = "my-org"
+repo                = "platform-configs"
+path                = "merge-warden/org-policy.toml"
+fail_if_unreachable = false
+```
+
+The GitHub App must have `Contents: Read` permission on the policy repository.
+
+See [Configure an organisation-level policy](../how-to/configure-org-policy.md) for
+setup instructions and the org policy file format.
+
+---
+
 ## `[policies.bypass_rules.*]`
 
 Three bypass sections are available: `title_convention`, `work_items`, `size`.
@@ -103,6 +178,13 @@ overridden by per-repo configs.
 ## Complete example
 
 ```toml
+# Optional — enable org-level policy from a central repository.
+# [org_policy_source]
+# owner               = "my-org"
+# repo                = "platform-configs"
+# path                = "merge-warden/org-policy.toml"
+# fail_if_unreachable = false
+
 [policies]
 enable_title_validation       = true
 default_invalid_title_label   = "pr-issue: invalid-title-format"
@@ -110,16 +192,21 @@ default_invalid_title_label   = "pr-issue: invalid-title-format"
 enable_work_item_validation      = true
 default_missing_work_item_label  = "pr-issue: missing-work-item"
 
+# Bot mention prefix for label-suppression commands posted in PR comments.
+# Change this if your GitHub App is installed under a different name.
+# bot_mention = "@merge-warden"
+
 [policies.pr_size_check]
-enabled          = false
+enabled           = false
 fail_on_oversized = false
-label_prefix     = "size/"
-add_comment      = true
+label_prefix      = "size/"
+add_comment       = true
+ignore_deletions  = false
 
 [policies.wip_check]
-enforce_wip_blocking  = true
-wip_label             = "WIP"
-wip_title_patterns    = ["WIP", "wip:", "[wip]", "draft:", "Draft:"]
+enforce_wip_blocking     = true
+wip_label                = "WIP"
+wip_title_patterns       = ["WIP", "wip:", "[wip]", "draft:", "Draft:"]
 wip_description_patterns = []
 
 [policies.pr_state_labels]
@@ -127,6 +214,10 @@ enabled        = true
 draft_label    = "status: draft"
 review_label   = "status: in-review"
 approved_label = "status: approved"
+
+[policies.renovate_stability]
+enabled                = true
+pending_stability_label = "pr-validation: pending-stability"
 
 [policies.bypass_rules.title_convention]
 enabled = false

--- a/docs/user/reference/app-config.md
+++ b/docs/user/reference/app-config.md
@@ -113,9 +113,13 @@ Controls the Renovate stability-days label management feature at the application
 | `enabled` | bool | `true` | When `true`, the `pending_stability_label` is applied to a PR while its `renovate/stability-days` commit status is `pending`, `error`, or `failure`. Removed when the status becomes `success`. |
 | `pending_stability_label` | string | `"pr-validation: pending-stability"` | Name of the label applied during the stability wait period. |
 
-The merge rule for `enabled` is OR: once either the application tier or the per-repo
-tier enables this feature, it stays enabled. To disable for all repositories, set
-`enabled = false` here (individual repos cannot override it back to `false`).
+The merge rule for `enabled` is OR: the feature is active when either the application
+tier or the per-repo tier has `enabled = true`. Because the per-repo
+`[policies.pullRequests.renovateStability]` defaults to `enabled = true`, repositories
+with any `.github/merge-warden.toml` (even one that does not mention this section) will
+keep the feature enabled. Setting `enabled = false` here only disables the feature for
+repositories that have no per-repo config file at all. To disable the feature for a
+specific repository, set `enabled = false` in that repository's `.github/merge-warden.toml`.
 
 **Example:**
 

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -185,7 +185,7 @@ auth_method = "app"
 
 [webhooks]
 # Webhook server port
-port = 3000
+port = 3100
 
 [policies]
 # Application-level policy defaults — see app-config reference

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -52,8 +52,8 @@ merge-warden checkpr --provider github
 merge-warden checkpr --provider github --config /path/to/config.toml
 ```
 
-The server listens on `http://localhost:3000` by default. Configure your GitHub App webhook
-URL (or smee relay target) to `http://localhost:3000/api/github/webhook`.
+The server listens on `http://localhost:3100` by default. Configure your GitHub App webhook
+URL (or smee relay target) to `http://localhost:3100/api/github/webhook`.
 
 **Log level:** Controlled by the `MERGE_WARDEN_LOG` environment variable. The server
 container uses `RUST_LOG`; the CLI binary uses `MERGE_WARDEN_LOG`. See [Environment variables](environment-variables.md).
@@ -126,8 +126,9 @@ Prompts interactively for:
 
 1. **App ID** — the numeric App ID from your GitHub App settings page
 2. **Path to private key** — the filesystem path to the downloaded `.pem` file
+3. **Webhook secret** — the secret configured in the GitHub App webhook settings
 
-Credentials are stored in the system keyring under the `merge_warden_cli` service.
+All three values are stored in the system keyring under the `merge_warden_cli` service.
 
 ```bash
 merge-warden auth github app
@@ -138,6 +139,8 @@ merge-warden auth github app
 # 123456
 # Path to private key file:
 # /home/user/.config/merge-warden/private-key.pem
+# Webhook secret:
+# <your-webhook-secret>
 ```
 
 #### `auth github token` — Personal access token authentication

--- a/docs/user/reference/per-repo-config.md
+++ b/docs/user/reference/per-repo-config.md
@@ -141,10 +141,11 @@ pending_stability_label = "pr-validation: pending-stability"
 | `pending_stability_label` | string | `"pr-validation: pending-stability"` | Label applied while the `renovate/stability-days` status is `pending`, `error`, or `failure`. |
 
 > **Note:** The label is purely informational and never affects the Merge Warden check
-> result. Setting `enabled = false` at the repo level has no effect if the application
-> defaults have `enabled = true`; once either tier enables this feature it stays enabled.
-> To disable it for all repositories, set `enabled = false` in the application-level
-> configuration.
+> result. The merge rule for `enabled` is OR: once either tier enables this feature it
+> stays enabled. To disable it for a specific repository, set `enabled = false` explicitly
+> in that repository's `.github/merge-warden.toml`. Setting `enabled = false` in the
+> application-level configuration only suppresses the feature for repositories that have
+> no per-repo config file.
 
 ---
 

--- a/docs/user/reference/per-repo-config.md
+++ b/docs/user/reference/per-repo-config.md
@@ -121,6 +121,33 @@ Controls propagation of issue metadata onto pull requests.
 
 ---
 
+## `[policies.pullRequests.renovateStability]`
+
+Controls the Renovate stability-days label. When enabled, Merge Warden watches for the
+`renovate/stability-days` commit status on the PR's head commit and applies a label while
+the status is pending.
+
+This section is **enabled by default**. Omitting it is equivalent to:
+
+```toml
+[policies.pullRequests.renovateStability]
+enabled = true
+pending_stability_label = "pr-validation: pending-stability"
+```
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `enabled` | bool | `true` | When `true`, the `pending_stability_label` is applied while the Renovate stability period has not elapsed. The label is removed when the status becomes `success`. |
+| `pending_stability_label` | string | `"pr-validation: pending-stability"` | Label applied while the `renovate/stability-days` status is `pending`, `error`, or `failure`. |
+
+> **Note:** The label is purely informational and never affects the Merge Warden check
+> result. Setting `enabled = false` at the repo level has no effect if the application
+> defaults have `enabled = true`; once either tier enables this feature it stays enabled.
+> To disable it for all repositories, set `enabled = false` in the application-level
+> configuration.
+
+---
+
 ## `[policies.bypassRules.*]`
 
 Each bypass section has the same shape. Three bypass policies are available:
@@ -205,6 +232,41 @@ Hex colour codes used when creating fallback labels. One entry per commit type.
 | `prefix_match` | bool | `true` | Match label name that starts with a common prefix and the candidate (e.g. `type: feat`). |
 | `description_match` | bool | `true` | Match label whose description contains one of the candidate values. |
 | `common_prefixes` | array of strings | `["type:", "kind:", "category:"]` | Prefixes used when `prefix_match` is enabled. |
+
+### `[change_type_labels.keyword_labels]`
+
+Controls labels that are applied when specific keywords are detected in the PR title or
+body. All four fields are optional; omit a field to use the built-in default label name.
+
+| Field | Type | Default | Trigger condition |
+| :--- | :--- | :--- | :--- |
+| `breaking_change` | string | `"breaking-change"` | PR title contains `!:` (breaking-change conventional commit), or PR body contains the phrase `breaking change` or `breaking-change`. |
+| `security` | string | `"security"` | PR body contains the word `security` or `vulnerability`. |
+| `hotfix` | string | `"hotfix"` | PR body contains the word `hotfix`. |
+| `tech_debt` | string | `"tech-debt"` | PR body contains `tech debt`, `tech-debt`, `technical debt`, or `technical-debt`. |
+
+Keyword matching uses word-boundary detection and is case-insensitive. Negation context
+is also detected — phrases such as "no breaking change" or "doesn't introduce a security
+issue" do not trigger the corresponding label.
+
+When a keyword label is applied, Merge Warden posts an explanatory comment on the PR.
+The comment includes the suppression command that can be used to prevent the label from
+being re-applied. See [Suppress keyword-triggered labels](../how-to/configure-label-suppression.md).
+
+**Example — custom label names:**
+
+```toml
+schemaVersion = 1
+
+[change_type_labels]
+enabled = true
+
+[change_type_labels.keyword_labels]
+breaking_change = "semver: breaking"
+security        = "sec: vulnerability"
+hotfix          = "priority: hotfix"
+tech_debt       = "quality: tech-debt"
+```
 
 ---
 


### PR DESCRIPTION
Add and update user docs to cover features present in code but missing from docs: Renovate stability label management, keyword-triggered labels, label suppression via bot comments, org-level policy configuration, config file auto-validation, and fix two CLI reference errors (missing webhook secret prompt in auth flow, wrong default port 3000 → 3100).

New files:
- docs/user/how-to/configure-renovate-stability.md
- docs/user/how-to/configure-label-suppression.md
- docs/user/how-to/configure-org-policy.md

Updated files:
- docs/user/reference/per-repo-config.md
- docs/user/reference/app-config.md
- docs/user/reference/cli.md
- docs/user/explanation/config-precedence.md
- docs/user/explanation/how-merge-warden-works.md
- docs/user/how-to/configure-change-type-labels.md
- docs/user/index.md
