### PR TITLE
docs: add Commit statuses permission and webhook for Renovate stability (FR008)

### DIFF
--- a/docs/user/reference/github-app-permissions.md
+++ b/docs/user/reference/github-app-permissions.md
@@ -16,6 +16,7 @@ on the GitHub App that Merge Warden uses. Create or update the app at
 | Permission | Level | Why it is needed |
 | :--- | :--- | :--- |
 | Checks | Read & Write | Create and update check runs on pull requests |
+| Commit statuses | Read | Read commit statuses to detect Renovate stability-days transitions |
 | Contents | Read | Read `.github/merge-warden.toml` from the default branch |
 | Issues | Read | Read issue metadata for milestone and project propagation (GitHub issues only) |
 | Labels | Read & Write | Apply labels to pull requests; create fallback labels when none match |
@@ -52,6 +53,7 @@ Subscribe the GitHub App to the following events:
 
 | Event | Why it is needed |
 | :--- | :--- |
+| Commit statuses | Trigger Renovate stability-days label updates when a commit status transitions (e.g. `pending` → `success`) |
 | Pull request | Trigger processing when a PR is opened, edited, synchronised, reopened, or converted from draft |
 | Pull request review | Trigger state-label updates when a review is submitted |
 


### PR DESCRIPTION
## Summary

- Adds `Commit statuses | Read` to the repository permissions table — required for `GET /repos/{owner}/{repo}/commits/{sha}/statuses` called by the FR008 stability label handler
- Adds `Commit statuses` to the webhook events table — required so the `handle_status_event` handler fires when Renovate transitions `renovate/stability-days` from `pending` → `success`

These were the two missing entries in the GitHub App permissions reference after #303 shipped FR008.

## Test plan

- [ ] Review that the two new table rows are accurate and complete
- [ ] Verify the existing rows are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)