### PR TITLE
chore: Adding a VSCode settings file to get a sensible window title

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "window.title": "merge-warden - ${activeRepositoryBranchName}${separator}${activeEditorShort}${dirty}"
+}


### PR DESCRIPTION
So that the VsCode window title shows the repository name when we open it in a git worktree