### PR TITLE
fix(ci): prevent crates.io HTTP2 download failures and catch them in PR builds

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,11 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # Disable HTTP/2 multiplexing to avoid curl "Error in the HTTP2 framing
+  # layer" transient failures when downloading crates from crates.io.
+  CARGO_HTTP_MULTIPLEXING: "false"
+  # Retry failed network operations up to 3 times before giving up.
+  CARGO_NET_RETRY: "3"
 
 jobs:
   # ── Security gate (runs first, blocks everything else) ────────────────────
@@ -389,12 +394,6 @@ jobs:
     if: needs.changes.outputs.integration == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
-    env:
-      # Disable HTTP/2 multiplexing to avoid curl "Error in the HTTP2 framing
-      # layer" transient failures when downloading crates from crates.io.
-      CARGO_HTTP_MULTIPLEXING: "false"
-      # Retry failed network operations up to 3 times before giving up.
-      CARGO_NET_RETRY: "3"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -379,6 +379,66 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # ── CLI cross-target build validation ────────────────────────────────────
+  # Mirrors the matrix used by release.yml so cross-compilation failures are
+  # caught on PRs rather than at release time.
+
+  build-cli-validate:
+    name: Validate CLI build - ${{ matrix.target }}
+    needs: [security-gate, changes]
+    if: needs.changes.outputs.integration == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    env:
+      # Disable HTTP/2 multiplexing to avoid curl "Error in the HTTP2 framing
+      # layer" transient failures when downloading crates from crates.io.
+      CARGO_HTTP_MULTIPLEXING: "false"
+      # Retry failed network operations up to 3 times before giving up.
+      CARGO_NET_RETRY: "3"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-22.04
+          - target: x86_64-pc-windows-msvc
+            os: windows-2022
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: taiki-e/setup-cross-toolchain-action@3d9770ce98eb7dbcf378563182a5e8031165f75b # v1
+        with:
+          target: ${{ matrix.target }}
+        if: startsWith(matrix.os, 'ubuntu') && !contains(matrix.target, '-musl')
+
+      - uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2
+        with:
+          tool: cross
+        if: contains(matrix.target, '-musl')
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Set static CRT for Windows
+        run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >>
+          "${GITHUB_ENV}"
+        shell: bash
+        if: endsWith(matrix.target, 'windows-msvc')
+
+      - name: Build CLI binary (musl via cross)
+        run: cross build --target ${{ matrix.target }} --bin merge-warden
+        if: contains(matrix.target, '-musl')
+
+      - name: Build CLI binary
+        run: cargo build --target ${{ matrix.target }} --bin merge-warden
+        if: "!contains(matrix.target, '-musl')"
+
   # ── Integration Tests ─────────────────────────────────────────────────────
 
   integration-tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,12 @@ jobs:
             os: windows-2022
             archive_ext: zip
     timeout-minutes: 60
+    env:
+      # Disable HTTP/2 multiplexing to avoid curl "Error in the HTTP2 framing
+      # layer" transient failures when downloading crates from crates.io.
+      CARGO_HTTP_MULTIPLEXING: "false"
+      # Retry failed network operations up to 3 times before giving up.
+      CARGO_NET_RETRY: "3"
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -208,6 +214,12 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             arch: arm64
     timeout-minutes: 60
+    env:
+      # Disable HTTP/2 multiplexing to avoid curl "Error in the HTTP2 framing
+      # layer" transient failures when downloading crates from crates.io.
+      CARGO_HTTP_MULTIPLEXING: "false"
+      # Retry failed network operations up to 3 times before giving up.
+      CARGO_NET_RETRY: "3"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,13 @@ permissions:
   id-token: write # sign attestations via Sigstore/Fulcio
   attestations: write # store attestations in GitHub
 
+env:
+  # Disable HTTP/2 multiplexing to avoid curl "Error in the HTTP2 framing
+  # layer" transient failures when downloading crates from crates.io.
+  CARGO_HTTP_MULTIPLEXING: "false"
+  # Retry failed network operations up to 3 times before giving up.
+  CARGO_NET_RETRY: "3"
+
 jobs:
   resolve-version:
     name: Resolve Release Version
@@ -74,12 +81,6 @@ jobs:
             os: windows-2022
             archive_ext: zip
     timeout-minutes: 60
-    env:
-      # Disable HTTP/2 multiplexing to avoid curl "Error in the HTTP2 framing
-      # layer" transient failures when downloading crates from crates.io.
-      CARGO_HTTP_MULTIPLEXING: "false"
-      # Retry failed network operations up to 3 times before giving up.
-      CARGO_NET_RETRY: "3"
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -214,12 +215,6 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             arch: arm64
     timeout-minutes: 60
-    env:
-      # Disable HTTP/2 multiplexing to avoid curl "Error in the HTTP2 framing
-      # layer" transient failures when downloading crates from crates.io.
-      CARGO_HTTP_MULTIPLEXING: "false"
-      # Retry failed network operations up to 3 times before giving up.
-      CARGO_NET_RETRY: "3"
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

The release build for tag 0.7.1 failed on the `x86_64-unknown-linux-gnu` CLI target with:

```
[16] Error in the HTTP2 framing layer (Send failure: Connection reset by peer)
```

This is a known curl bug triggered when HTTP/2 multiplexing is active and the TCP connection is reset mid-stream while downloading crates from crates.io. It is a transient infrastructure issue, but without mitigations it causes a hard build failure.

A second issue was identified: the PR pipeline never exercised the release cross-compilation targets, so this class of failure was invisible until release time.

## Fixes

### 1. Disable HTTP/2 multiplexing + add retries (`release.yml`)

Added to both `build-cli` and `build-server` jobs:

```yaml
env:
  CARGO_HTTP_MULTIPLEXING: "false"  # disables the curl HTTP/2 feature that triggers the bug
  CARGO_NET_RETRY: "3"              # retries transient network failures 3× before failing
```

### 2. Add cross-target build validation to PR pipeline (`pr.yml`)

Added a new `build-cli-validate` matrix job that mirrors the exact same targets as `release.yml`:
- `x86_64-unknown-linux-gnu`
- `x86_64-unknown-linux-musl`
- `x86_64-pc-windows-msvc`

Uses a debug build (no `--release`) to keep CI fast while still exercising the full cross-toolchain setup. Carries the same `CARGO_HTTP_MULTIPLEXING`/`CARGO_NET_RETRY` env vars so PR builds are equally resilient.