### PR TITLE
docs: fill user-doc gaps for repository scope filtering and queue mode

### DIFF
--- a/docs/spec/requirements/functional-requirements.md
+++ b/docs/spec/requirements/functional-requirements.md
@@ -129,7 +129,7 @@ This document specifies the functional requirements that define what Merge Warde
 
 **Description:**
 
-- Deploy as Azure Functions for cloud-based webhook processing
+- Deploy as a container for cloud-based webhook processing (Azure Container Apps, AWS ECS, etc.)
 - Provide CLI tool for local and CI/CD environment usage
 - Support container-based deployments
 - Enable cross-platform compatibility
@@ -137,7 +137,7 @@ This document specifies the functional requirements that define what Merge Warde
 
 **Acceptance Criteria:**
 
-- ✅ Azure Functions deployment and operation
+- ✅ Container deployment and operation (Azure Container Apps, AWS ECS)
 - ✅ CLI tool functionality and distribution
 - ✅ Container image creation and deployment
 - ✅ Cross-platform binary compilation
@@ -402,12 +402,12 @@ Organisation permissions:
 
 ### Azure Services Integration
 
-**Azure Functions:**
+**Azure Container Apps:**
 
-- HTTP trigger for webhook processing
-- Timer trigger for maintenance tasks
-- Event-driven scaling and execution
-- Integration with Azure Monitor and Application Insights
+- HTTP ingress for webhook processing
+- Health-check endpoint (`GET /health`) for liveness/readiness probes
+- Request-driven autoscaling
+- OTLP telemetry export to Application Insights via the Azure Monitor OpenTelemetry Distro collector
 
 **Azure App Configuration:**
 

--- a/docs/user/explanation/config-precedence.md
+++ b/docs/user/explanation/config-precedence.md
@@ -27,6 +27,36 @@ per-repository config → compiled-in defaults).
 
 ---
 
+## Repository scope filtering runs before any of this
+
+`[policies.repository_scope]` (application-level config only) is **not** one of the four
+layers above. It is evaluated once, as a webhook-ingress-level gate, before any
+configuration is resolved at all — before the org-level policy fetch, before the
+per-repository config fetch, and before compiled-in defaults are even consulted.
+
+The practical consequence: a repository excluded by `[policies.repository_scope]` cannot
+re-include itself by any means available to a repository maintainer. Its
+`.github/merge-warden.toml` is never fetched, so there is nothing for it to override — the
+usual "per-repo config overrides application defaults" rule described below simply never
+gets a chance to run for that repository. The same is true of org-level `[enforced]`
+policies: an org-enforced policy cannot force processing of a repository that scope
+filtering has already excluded, because scope filtering runs first.
+
+This is a deliberate design choice. Large organisations are often forced into installing
+their GitHub App with "All repositories" access — GitHub does not offer a way to select
+individual repositories once an organisation passes a certain size — which means the app
+receives webhooks for repositories it was never intended to act on. Repository scope
+filtering gives the operator a way to declare, independently of GitHub's installation
+scope, which repositories should actually be processed. Because this is a decision about
+*whether an event is processed at all* rather than *how it is validated*, it sits outside
+the policy-merging model entirely instead of being awkwardly bolted on as a fifth
+precedence layer.
+
+See [Configure repository scope filtering](../how-to/configure-repository-scope.md) for
+setup instructions.
+
+---
+
 ## The four layers
 
 ### Layer 1 — Compiled-in defaults
@@ -88,6 +118,26 @@ per-repo value overrides the application-level value for that field — unless t
 `[enforced]` section has already set `required = true` for that field, in which case the
 enforced value wins.
 
+### Exception: the Renovate-stability `enabled` merge rule is OR, not override
+
+Most boolean fields follow the plain override rule above: whichever tier sets the field
+wins, full stop. `renovate_stability.enabled` /
+`[policies.pullRequests.renovateStability].enabled` is a deliberate exception — the
+effective value is `application_enabled OR per_repo_enabled`, not "whichever tier set it
+last."
+
+Because the per-repo field defaults to `enabled = true` (see
+[Per-repository configuration schema](../reference/per-repo-config.md#policiespullrequestsrenovatestability)),
+any repository with a `.github/merge-warden.toml` file — even one that never mentions
+Renovate stability — contributes `true` to that OR. This means
+`[policies.renovate_stability].enabled = false` at the application level only takes effect
+for repositories that have **no** per-repo config file at all. To disable the feature for a
+specific repository, you must set `enabled = false` explicitly in that repository's own
+`.github/merge-warden.toml`.
+
+See [Configure Renovate stability labels](../how-to/configure-renovate-stability.md) for
+worked examples.
+
 ---
 
 ## Example (three-tier, no org policy)
@@ -130,5 +180,6 @@ defaults, no checks fail and no labels are applied.
 
 - [Why there are two configuration files](two-config-files.md)
 - [Configure an organisation-level policy](../how-to/configure-org-policy.md)
+- [Configure repository scope filtering](../how-to/configure-repository-scope.md)
 - [Application configuration schema](../reference/app-config.md)
 - [Per-repository configuration schema](../reference/per-repo-config.md)

--- a/docs/user/explanation/how-merge-warden-works.md
+++ b/docs/user/explanation/how-merge-warden-works.md
@@ -24,6 +24,9 @@ HMAC-SHA256 signature verification
     ↓  (rejected with 401 if signature is invalid)
 202 Accepted returned to GitHub  ← response sent here, before processing
     ↓
+Repository scope check (if [policies.repository_scope] is configured)
+    ↓  (out-of-scope repositories are acknowledged and dropped here — no
+    ↓   further steps run, no GitHub API call is made)
 Event routing — only pull_request and pull_request_review events proceed
     ↓
 Per-repository config loaded from .github/merge-warden.toml via GitHub API
@@ -38,9 +41,18 @@ verified, before any policy evaluation or GitHub API calls. This ensures Merge W
 responds within GitHub's 10-second webhook delivery timeout regardless of how long
 downstream processing takes. Processing happens after the response is sent.
 
-> **In `queue` mode**, the payload is additionally persisted to a queue before the response
-> is returned, and a separate consumer task performs the policy evaluation. See
-> [Webhook vs queue receiver modes](receiver-modes.md) for details.
+The repository scope check is the **first** thing evaluated once processing begins —
+before Merge Warden even looks at the event type, and before any repository-specific data
+(config file, org policy, topics, custom properties) is fetched. A webhook payload with a
+missing or unparseable `repository.name` is also treated as out of scope. See
+[How to configure repository scope filtering](../how-to/configure-repository-scope.md).
+
+> **In `queue` mode**, Merge Warden itself does not perform the steps above the repository
+> scope check. It exposes no webhook POST endpoint at all — a wholly separate receiver
+> service performs webhook receipt, HMAC verification, and enqueueing, and Merge Warden
+> consumes the resulting message from the queue. The repository scope check and everything
+> below it runs the same way regardless of receiver mode. See
+> [Webhook vs queue receiver modes](receiver-modes.md) for the full architecture.
 
 ---
 

--- a/docs/user/explanation/receiver-modes.md
+++ b/docs/user/explanation/receiver-modes.md
@@ -43,20 +43,31 @@ GitHub
 
 ## `queue` mode
 
-The server receives the incoming webhook, verifies the HMAC signature, and enqueues the
-payload. A separate consumer task processes events from the queue asynchronously.
+> **This is a two-service architecture, not a single-container mode switch.**
+> In `queue` mode, the Merge Warden server itself becomes a **pure queue
+> consumer**. It does **not** expose a webhook POST endpoint — only
+> `GET /health` is registered. A separate, independent service must receive
+> the GitHub webhook, verify the `X-Hub-Signature-256` HMAC signature, and
+> enqueue the payload. Do not point GitHub's webhook URL at the Merge Warden
+> container when running in `queue` mode — there is nothing there to receive
+> it.
 
 ```
-GitHub
-  POST /api/github/webhook
-      ↓
-  HMAC verification
-      ↓
-  Payload enqueued
-      ↓
-  202 Accepted returned to GitHub immediately
+Separate receiver service (not Merge Warden)
+  GitHub
+    POST <receiver's webhook URL>
+        ↓
+    HMAC verification
+        ↓
+    Payload enqueued
+        ↓
+    202 Accepted returned to GitHub
 
-  (separately)
+                    ↓ (queue)
+
+Merge Warden container (MERGE_WARDEN_RECEIVER_MODE=queue)
+  Only route registered: GET /health
+      ↓
   Consumer reads from queue
       ↓
   Policy evaluation
@@ -66,16 +77,34 @@ GitHub
 
 **Characteristics:**
 
-- The HTTP response to GitHub is returned as soon as the payload is enqueued — before any
-  policy evaluation occurs.
-- Useful when processing a large volume of PR events simultaneously. In webhook mode each
-  request ties up a server thread until processing completes; concentrated bursts can
-  exhaust available threads and cause the server to drop incoming requests. Queue mode
-  decouples receipt from processing so bursts are absorbed by the queue.
-- Useful for bursty traffic patterns (e.g. many PRs opened at the same time during a
-  release freeze lift) where webhook mode could be momentarily overwhelmed.
-- Requires additional infrastructure for the queue.
-- Processing results (labels, check runs) appear on the pull request with a slight delay.
+- Merge Warden's own HTTP server exposes only the health-check endpoint in
+  this mode — no `/api/github/webhook` route is registered. It never
+  validates a webhook signature and never receives a webhook payload
+  directly.
+- `GITHUB_WEBHOOK_SECRET` is not used by Merge Warden in this mode —
+  signature validation is the separate receiver service's responsibility. See
+  [Environment variables reference](../reference/environment-variables.md).
+- You must operate (or otherwise provision) the separate receiver service
+  yourself. It is responsible for accepting the GitHub webhook POST, verifying
+  the HMAC signature, and publishing a message to the queue in the format the
+  configured queue provider expects.
+- Useful when processing a large volume of PR events simultaneously. In webhook
+  mode each request ties up a server thread until processing completes;
+  concentrated bursts can exhaust available threads and cause the server to
+  drop incoming requests. Queue mode decouples receipt from processing so
+  bursts are absorbed by the queue.
+- Useful for bursty traffic patterns (e.g. many PRs opened at the same time
+  during a release freeze lift) where webhook mode could be momentarily
+  overwhelmed.
+- Requires additional infrastructure: the queue itself (Azure Service Bus, AWS
+  SQS, or an in-memory queue for local testing only) and the separate receiver
+  service.
+- Processing results (labels, check runs) appear on the pull request with a
+  slight delay relative to webhook mode.
+
+See [How to run Merge Warden in queue mode](../how-to/run-in-queue-mode.md) for
+setup details, including what the receiver service must do and the queue
+provider environment variables.
 
 ---
 
@@ -87,11 +116,13 @@ GitHub
 | Processing consistently takes more than a few seconds | `queue` |
 | High PR volume or bursty traffic (e.g. many PRs opened simultaneously) | `queue` |
 | You cannot afford to lose events if the server is briefly overloaded | `queue` |
-| You want the simplest possible deployment | `webhook` |
+| You want the simplest possible deployment (single container, no extra service) | `webhook` |
 | You need resilience against transient downstream failures | `queue` |
+| You are not able to stand up and operate a separate receiver service | `webhook` |
 
 Most deployments should use `webhook` mode. Switch to `queue` only if you observe GitHub
-reporting webhook delivery timeouts in the App settings.
+reporting webhook delivery timeouts in the App settings, and only if you can operate the
+additional receiver service that queue mode requires.
 
 ---
 
@@ -103,7 +134,9 @@ Set the mode via environment variable:
 # Default — no setting needed
 MERGE_WARDEN_RECEIVER_MODE=webhook
 
-# Queue mode
+# Queue mode — also requires MERGE_WARDEN_QUEUE_PROVIDER and, depending on
+# provider, additional variables. See the environment variables reference and
+# the queue-mode how-to guide linked above.
 MERGE_WARDEN_RECEIVER_MODE=queue
 ```
 
@@ -111,5 +144,6 @@ MERGE_WARDEN_RECEIVER_MODE=queue
 
 ## Related
 
+- [How to run Merge Warden in queue mode](../how-to/run-in-queue-mode.md)
 - [Environment variables reference](../reference/environment-variables.md)
 - [HTTP endpoints reference](../reference/http-endpoints.md)

--- a/docs/user/how-to/configure-bypass-rules.md
+++ b/docs/user/how-to/configure-bypass-rules.md
@@ -55,13 +55,10 @@ list has no effect when `enabled = false`.
 
 ## Security considerations
 
-Bypass user lists are specified in the **per-repository configuration file** (`.github/merge-warden.toml`),
-which is stored in the repository itself. Anyone with write access to the default branch can
-add themselves to a bypass list.
-
-For stricter control, define bypass lists in the **application-level configuration file**
-(`MERGE_WARDEN_CONFIG_FILE`), which is controlled by the operator and cannot be overridden
-by repository maintainers. See [Set application-level policy defaults](set-app-level-defaults.md).
+Per-repo bypass lists are editable by anyone with write access to the repository's default
+branch. For a full discussion of the security tradeoffs and why you might prefer
+application-level or org-level bypass lists instead, see
+[Bypass rules in depth](../explanation/bypass-rules.md#security-considerations).
 
 Bypass rules **can also be set in the org-level policy file** (`merge-warden-org-policy.toml`), giving platform teams a central place to configure standard bot bypasses:
 

--- a/docs/user/how-to/configure-renovate-stability.md
+++ b/docs/user/how-to/configure-renovate-stability.md
@@ -42,12 +42,11 @@ No configuration file entry is required. The defaults are:
 
 ## Disabling the feature
 
-The merge rule for `enabled` is OR: the feature is active when **either** the
-application tier or the per-repo tier has `enabled = true`. Because the per-repo
-`[policies.pullRequests.renovateStability]` section defaults to `enabled = true`, any
-repository that has a `.github/merge-warden.toml` file (even one that does not mention
-Renovate stability at all) will keep the feature enabled regardless of the
-application-level setting.
+`enabled` merges via OR, not plain override: the feature is active when **either** the
+application tier or the per-repo tier has `enabled = true`. See
+[Configuration precedence — the Renovate-stability `enabled` merge rule](../explanation/config-precedence.md#exception-the-renovate-stability-enabled-merge-rule-is-or-not-override)
+for why this means application-level `enabled = false` alone is not enough to disable the
+feature for a repository that has its own config file.
 
 To fully disable the feature for a repository, set `enabled = false` explicitly in
 that repository's `.github/merge-warden.toml`:
@@ -66,11 +65,6 @@ that have no `.github/merge-warden.toml` at all), set it in `MERGE_WARDEN_CONFIG
 [policies.renovate_stability]
 enabled = false
 ```
-
-> **Note:** The application-level `enabled = false` does not suppress the feature for
-> repositories that have their own `.github/merge-warden.toml`, because the per-repo
-> defaults contribute `enabled = true` via the OR merge rule. Repositories that need
-> the feature off must set `enabled = false` in their own config file.
 
 ---
 

--- a/docs/user/how-to/configure-repository-scope.md
+++ b/docs/user/how-to/configure-repository-scope.md
@@ -1,0 +1,117 @@
+---
+title: "How to configure repository scope filtering"
+description: "Restrict which repositories Merge Warden actively processes, independent of GitHub App installation scope."
+---
+
+# How to configure repository scope filtering
+
+Add the `[policies.repository_scope]` section to the application-level configuration file
+(`MERGE_WARDEN_CONFIG_FILE`) to restrict which repositories Merge Warden actively processes.
+This is an operator-only setting — it cannot be set in a repository's own
+`.github/merge-warden.toml`.
+
+This section is optional. Omitting it entirely processes every repository the GitHub App is
+installed on, preserving the pre-existing behaviour.
+
+---
+
+## Allow-listing specific repositories
+
+```toml
+# In the application-level config file (MERGE_WARDEN_CONFIG_FILE)
+[policies.repository_scope]
+include_patterns = ["payments-*", "checkout", "billing-?"]
+exclude_patterns = ["payments-legacy"]
+```
+
+With this configuration:
+
+- `payments-api`, `payments-web`, `checkout`, and `billing-1` are processed (they match an
+  `include_patterns` entry).
+- `payments-legacy` is **not** processed, even though it matches `payments-*`, because
+  `exclude_patterns` takes precedence over `include_patterns`.
+- `inventory-service` is not processed — it matches no `include_patterns` entry.
+
+`exclude_patterns` is optional and defaults to an empty list when omitted.
+
+---
+
+## Pausing all processing (fail-closed kill switch)
+
+Set `include_patterns` to an explicit empty list to stop Merge Warden from processing
+**any** repository, regardless of `exclude_patterns`:
+
+```toml
+[policies.repository_scope]
+include_patterns = []
+```
+
+This is a deliberate fail-closed lever — useful as an emergency "pause everything" switch
+(for example, while investigating an incident) without having to uninstall the GitHub App
+or tear down the deployment. Restore normal operation by either removing the
+`[policies.repository_scope]` section entirely or by setting `include_patterns` back to a
+non-empty list.
+
+---
+
+## Pattern syntax
+
+| Wildcard | Matches |
+| :--- | :--- |
+| `*` | Any sequence of characters (including none) |
+| `?` | Exactly one character |
+
+Every other character is matched literally. Patterns are matched **case-insensitively**
+against the bare repository name (not `owner/repo` — only the `repo` part), and the match
+is anchored to the full name (a pattern must match the entire repository name, not a
+substring of it).
+
+Examples:
+
+| Pattern | Matches | Does not match |
+| :--- | :--- | :--- |
+| `payments-*` | `payments-api`, `payments-` | `my-payments-api` |
+| `billing-?` | `billing-1`, `billing-x` | `billing-12`, `billing-` |
+| `checkout` | `checkout`, `CheckOut` (case-insensitive) | `checkout-v2` |
+
+A pattern containing characters other than letters, digits, `-`, `_`, `*`, and `?` is
+rejected at server startup with a configuration error — Merge Warden fails fast rather than
+silently matching nothing (or everything) at webhook-handling time.
+
+---
+
+## What happens to filtered-out repositories
+
+For a repository outside the configured scope:
+
+- The event is acknowledged (no error, no retry triggered on GitHub's side) but no further
+  processing occurs.
+- No `.github/merge-warden.toml`, org-policy, topics, or custom-properties fetch happens.
+- No GitHub API call is made on behalf of that repository at all.
+- A webhook payload with a missing or malformed `repository.name` field is also treated as
+  out of scope (fail-closed), regardless of `[policies.repository_scope]` configuration.
+
+See [How Merge Warden works — the event lifecycle](../explanation/how-merge-warden-works.md)
+for where this check runs relative to the rest of event processing.
+
+---
+
+## Interaction with per-repository and org-level configuration
+
+Repository scope filtering is evaluated **before** any configuration is resolved — it is
+not part of the four-layer configuration precedence chain described in
+[Configuration precedence](../explanation/config-precedence.md). This has one important
+consequence: a repository excluded by `[policies.repository_scope]` cannot re-include
+itself via its own `.github/merge-warden.toml`. That file is never fetched for an
+out-of-scope repository, so there is nothing for it to override. See
+[Configuration precedence — repository scope filtering runs first](../explanation/config-precedence.md#repository-scope-filtering-runs-before-any-of-this)
+for details.
+
+---
+
+## Related
+
+- [Application configuration schema — policies.repository_scope](../reference/app-config.md#policiesrepository_scope)
+- [Configuration precedence](../explanation/config-precedence.md)
+- [How Merge Warden works](../explanation/how-merge-warden-works.md)
+- [Set application-level policy defaults](set-app-level-defaults.md)

--- a/docs/user/how-to/configure-repository-scope.md
+++ b/docs/user/how-to/configure-repository-scope.md
@@ -74,7 +74,7 @@ Examples:
 | `billing-?` | `billing-1`, `billing-x` | `billing-12`, `billing-` |
 | `checkout` | `checkout`, `CheckOut` (case-insensitive) | `checkout-v2` |
 
-A pattern containing characters other than letters, digits, `-`, `_`, `*`, and `?` is
+A pattern containing characters other than letters, digits, `-`, `_`, `.`, `*`, and `?` is
 rejected at server startup with a configuration error — Merge Warden fails fast rather than
 silently matching nothing (or everything) at webhook-handling time.
 

--- a/docs/user/how-to/deploy-on-aws.md
+++ b/docs/user/how-to/deploy-on-aws.md
@@ -211,3 +211,4 @@ inside the container. See [Set application-level policy defaults](set-app-level-
 - [Environment variables reference](../reference/environment-variables.md)
 - [GitHub App permissions](../reference/github-app-permissions.md)
 - [Set application-level policy defaults](set-app-level-defaults.md)
+- [Run Merge Warden in queue mode](run-in-queue-mode.md) — for high-volume or bursty traffic instead of the webhook mode shown above

--- a/docs/user/how-to/deploy-on-azure.md
+++ b/docs/user/how-to/deploy-on-azure.md
@@ -193,3 +193,4 @@ az containerapp update \
 - [Environment variables reference](../reference/environment-variables.md)
 - [GitHub App permissions](../reference/github-app-permissions.md)
 - [Set application-level policy defaults](set-app-level-defaults.md)
+- [Run Merge Warden in queue mode](run-in-queue-mode.md) — for high-volume or bursty traffic instead of the webhook mode shown above

--- a/docs/user/how-to/run-in-queue-mode.md
+++ b/docs/user/how-to/run-in-queue-mode.md
@@ -86,6 +86,8 @@ Notes:
 - Your receiver service needs its own credential to *send* to the same namespace/queue
   (e.g. **Azure Service Bus Data Sender**).
 
+---
+
 ## Configure the Merge Warden consumer — AWS SQS
 
 ```bash
@@ -108,6 +110,8 @@ Notes:
   testing against a real SQS queue.
 - Grant the container's role permission to receive and delete messages on the target SQS
   queue. Grant your receiver service permission to send messages to the same queue.
+
+---
 
 ## Local testing — in-memory queue
 

--- a/docs/user/how-to/run-in-queue-mode.md
+++ b/docs/user/how-to/run-in-queue-mode.md
@@ -1,0 +1,157 @@
+---
+title: "How to run Merge Warden in queue mode"
+description: "Set up the separate receiver service and queue infrastructure that queue receiver mode requires."
+---
+
+# How to run Merge Warden in queue mode
+
+`MERGE_WARDEN_RECEIVER_MODE=queue` turns the Merge Warden container into a **pure queue
+consumer**. It does not expose a webhook POST endpoint — only `GET /health` is registered.
+You must provide a **separate service** that receives the GitHub webhook, verifies its
+HMAC signature, and enqueues the payload for Merge Warden to consume.
+
+If you have not already read
+[Webhook vs queue receiver modes](../explanation/receiver-modes.md), start there — this
+guide assumes you understand why queue mode is a two-service architecture, not a single
+container with a mode flag.
+
+---
+
+## What you need to build or provision
+
+Queue mode requires a component that this repository does not ship a ready-made
+implementation of: **the webhook receiver service**. At minimum it must:
+
+1. Accept an HTTPS POST from GitHub at whatever URL you configure as the GitHub App's
+   **Webhook URL**.
+2. Verify the `X-Hub-Signature-256` header against your webhook secret using HMAC-SHA256
+   (constant-time comparison). Reject invalid or missing signatures with `401`.
+3. Publish the validated payload to the same queue (name, provider, and region/namespace)
+   that the Merge Warden container is configured to consume from.
+4. Return `200`/`202` to GitHub promptly, within GitHub's 10-second webhook delivery
+   timeout.
+
+Common ways to build this: a small serverless function (Azure Function, AWS Lambda) that
+validates the signature and forwards to Azure Service Bus or SQS, or a lightweight sidecar
+container. The receiver service's implementation is outside Merge Warden's scope — Merge
+Warden only defines the consumer side.
+
+---
+
+## Choosing a queue provider
+
+Set `MERGE_WARDEN_QUEUE_PROVIDER` to one of:
+
+| Value | Backend | Use case |
+| :--- | :--- | :--- |
+| `azure` | Azure Service Bus | Production deployments on Azure |
+| `aws` | AWS SQS | Production deployments on AWS |
+| `memory` | In-process in-memory queue | Local development and testing only — **not durable**, not shared across processes, do not use in production |
+
+Any other value is rejected at startup with a configuration error.
+
+> **Planned, not yet available:** the underlying `queue-runtime` library Merge Warden
+> depends on also has the ability to talk to NATS and RabbitMQ, but Merge Warden's own
+> configuration loader does not yet expose them — there is no `nats` or `rabbitmq` value
+> for `MERGE_WARDEN_QUEUE_PROVIDER` today. Setting either one currently fails startup with
+> `Unknown queue provider '<value>'. Expected 'azure', 'aws', or 'memory'.` Use `azure` or
+> `aws` until this is wired up.
+
+---
+
+## Configure the Merge Warden consumer — Azure Service Bus
+
+```bash
+docker run --rm \
+  -e MERGE_WARDEN_GITHUB_APP_ID=12345 \
+  -e MERGE_WARDEN_GITHUB_APP_PRIVATE_KEY="$(cat private-key.pem)" \
+  -e MERGE_WARDEN_RECEIVER_MODE=queue \
+  -e MERGE_WARDEN_QUEUE_PROVIDER=azure \
+  -e MERGE_WARDEN_QUEUE_NAME=merge-warden-events \
+  -e MERGE_WARDEN_QUEUE_CONCURRENCY=4 \
+  -e AZURE_SERVICEBUS_NAMESPACE=my-namespace.servicebus.windows.net \
+  -p 3000:3000 \
+  ghcr.io/pvandervelde/merge-warden-server:latest
+```
+
+Notes:
+
+- `GITHUB_WEBHOOK_SECRET` is **not** set here — it is not read in queue mode. The receiver
+  service holds and validates the webhook secret.
+- Authentication to Azure Service Bus uses the default Azure credential chain (managed
+  identity when running in Azure, `az login` locally, or environment-based credentials).
+  There is no connection-string environment variable for the consumer side; grant the
+  container's identity a Service Bus data-plane role (e.g. **Azure Service Bus Data
+  Receiver**) on the namespace.
+- Your receiver service needs its own credential to *send* to the same namespace/queue
+  (e.g. **Azure Service Bus Data Sender**).
+
+## Configure the Merge Warden consumer — AWS SQS
+
+```bash
+docker run --rm \
+  -e MERGE_WARDEN_GITHUB_APP_ID=12345 \
+  -e MERGE_WARDEN_GITHUB_APP_PRIVATE_KEY="$(cat private-key.pem)" \
+  -e MERGE_WARDEN_RECEIVER_MODE=queue \
+  -e MERGE_WARDEN_QUEUE_PROVIDER=aws \
+  -e MERGE_WARDEN_QUEUE_NAME=merge-warden-events \
+  -e MERGE_WARDEN_QUEUE_CONCURRENCY=4 \
+  -e AWS_REGION=ap-southeast-2 \
+  -p 3000:3000 \
+  ghcr.io/pvandervelde/merge-warden-server:latest
+```
+
+Notes:
+
+- Prefer an IAM role (ECS task role, IRSA on EKS, EC2 instance profile) over
+  `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`. Only set the static-key variables for local
+  testing against a real SQS queue.
+- Grant the container's role permission to receive and delete messages on the target SQS
+  queue. Grant your receiver service permission to send messages to the same queue.
+
+## Local testing — in-memory queue
+
+```bash
+docker run --rm \
+  -e MERGE_WARDEN_GITHUB_APP_ID=12345 \
+  -e MERGE_WARDEN_GITHUB_APP_PRIVATE_KEY="$(cat private-key.pem)" \
+  -e MERGE_WARDEN_RECEIVER_MODE=queue \
+  -e MERGE_WARDEN_QUEUE_PROVIDER=memory \
+  -p 3000:3000 \
+  ghcr.io/pvandervelde/merge-warden-server:latest
+```
+
+The in-memory provider only exists within a single running process and is not durable
+across restarts. It is useful for exercising the queue-consumer code path locally but
+cannot receive messages from an external receiver service running in a different process.
+Use `azure` or `aws` (even against a dev/test namespace or queue) to test the full
+two-service flow end-to-end.
+
+---
+
+## Verifying the deployment
+
+`GET /health` is the only route available in queue mode:
+
+```bash
+curl -i http://localhost:3000/health
+# HTTP/1.1 200 OK
+```
+
+To confirm events are flowing, open or update a pull request in a repository the GitHub
+App is installed on, and check:
+
+1. Your receiver service's logs — did it accept the webhook and successfully enqueue?
+2. The Merge Warden container's logs — did it dequeue and process the message (labels
+   applied, check run updated)?
+3. The pull request's **Checks** tab on GitHub, with a short delay relative to webhook mode.
+
+---
+
+## Related
+
+- [Webhook vs queue receiver modes](../explanation/receiver-modes.md)
+- [Environment variables reference](../reference/environment-variables.md)
+- [HTTP endpoints reference](../reference/http-endpoints.md)
+- [Deploy on Azure Container Apps](deploy-on-azure.md)
+- [Deploy on AWS ECS / Fargate](deploy-on-aws.md)

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -33,6 +33,7 @@ size limits, and more.
 - [Deploy on Azure Container Apps](how-to/deploy-on-azure.md)
 - [Deploy on AWS ECS / Fargate](how-to/deploy-on-aws.md)
 - [Run the server locally](how-to/run-locally.md)
+- [Run Merge Warden in queue mode](how-to/run-in-queue-mode.md)
 - [Test webhooks with smee relay](how-to/test-with-smee.md)
 
 **Policy configuration**
@@ -49,6 +50,7 @@ size limits, and more.
 - [Configure bypass rules](how-to/configure-bypass-rules.md)
 - [Set application-level policy defaults](how-to/set-app-level-defaults.md)
 - [Configure an organisation-level policy](how-to/configure-org-policy.md)
+- [Configure repository scope filtering](how-to/configure-repository-scope.md)
 
 ## Reference
 

--- a/docs/user/reference/app-config.md
+++ b/docs/user/reference/app-config.md
@@ -113,13 +113,10 @@ Controls the Renovate stability-days label management feature at the application
 | `enabled` | bool | `true` | When `true`, the `pending_stability_label` is applied to a PR while its `renovate/stability-days` commit status is `pending`, `error`, or `failure`. Removed when the status becomes `success`. |
 | `pending_stability_label` | string | `"pr-validation: pending-stability"` | Name of the label applied during the stability wait period. |
 
-The merge rule for `enabled` is OR: the feature is active when either the application
-tier or the per-repo tier has `enabled = true`. Because the per-repo
-`[policies.pullRequests.renovateStability]` defaults to `enabled = true`, repositories
-with any `.github/merge-warden.toml` (even one that does not mention this section) will
-keep the feature enabled. Setting `enabled = false` here only disables the feature for
-repositories that have no per-repo config file at all. To disable the feature for a
-specific repository, set `enabled = false` in that repository's `.github/merge-warden.toml`.
+`enabled` merges via OR rather than plain override — see
+[Configuration precedence — the Renovate-stability `enabled` merge rule](../explanation/config-precedence.md#exception-the-renovate-stability-enabled-merge-rule-is-or-not-override)
+for why setting `enabled = false` here does not disable the feature for repositories that
+have their own `.github/merge-warden.toml`.
 
 **Example:**
 
@@ -179,6 +176,39 @@ overridden by per-repo configs.
 
 ---
 
+## `[policies.repository_scope]`
+
+Optional. Restricts which repositories Merge Warden actively processes, independent of
+which repositories the GitHub App installation can technically access. Has no per-repo
+equivalent — this is an operator-only, application-level setting.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `include_patterns` | array of strings | *(section omitted)* | Glob patterns (`*`, `?`) matched case-insensitively against the bare repository name. A repository must match at least one entry to be processed. An explicit empty list (`[]`) processes **no** repositories — a fail-closed "pause everything" lever. |
+| `exclude_patterns` | array of strings | `[]` | Glob patterns that take precedence over `include_patterns`. A repository matching an exclude pattern is never processed, even if it also matches an include pattern. |
+
+**Behaviour when the section is absent:** every repository the GitHub App is installed on
+is processed — full backward compatibility with deployments that predate this feature.
+
+**Example:**
+
+```toml
+[policies.repository_scope]
+include_patterns = ["payments-*", "checkout", "billing-?"]
+exclude_patterns = ["payments-legacy"]
+```
+
+This is evaluated as a webhook-ingress-level gate **before** the configuration resolution
+chain runs — it is not one of the tiers described in
+[Configuration precedence](../explanation/config-precedence.md), and a repository excluded
+here cannot re-include itself via its own `.github/merge-warden.toml` (that file is never
+fetched for an out-of-scope repository).
+
+See [Configure repository scope filtering](../how-to/configure-repository-scope.md) for
+worked examples and pattern syntax details.
+
+---
+
 ## Complete example
 
 ```toml
@@ -234,6 +264,13 @@ users   = []
 [policies.bypass_rules.size]
 enabled = false
 users   = []
+
+# Optional — restrict which repositories Merge Warden actively processes.
+# Omit this section entirely to process every repository the GitHub App is
+# installed on (the pre-existing, backward-compatible behaviour).
+# [policies.repository_scope]
+# include_patterns = ["payments-*", "checkout", "billing-?"]
+# exclude_patterns = ["payments-legacy"]
 ```
 
 ---
@@ -242,5 +279,6 @@ users   = []
 
 - [Per-repository configuration schema](per-repo-config.md)
 - [Set application-level defaults](../how-to/set-app-level-defaults.md)
+- [Configure repository scope filtering](../how-to/configure-repository-scope.md)
 - [Configuration precedence](../explanation/config-precedence.md)
 - [Why there are two configuration files](../explanation/two-config-files.md)

--- a/docs/user/reference/app-config.md
+++ b/docs/user/reference/app-config.md
@@ -184,7 +184,7 @@ equivalent — this is an operator-only, application-level setting.
 
 | Field | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `include_patterns` | array of strings | *(section omitted)* | Glob patterns (`*`, `?`) matched case-insensitively against the bare repository name. A repository must match at least one entry to be processed. An explicit empty list (`[]`) processes **no** repositories — a fail-closed "pause everything" lever. |
+| `include_patterns` | array of strings | *(section omitted)* | Glob patterns (`*`, `?`, plus literal letters, digits, `-`, `_`, `.`) matched case-insensitively against the bare repository name. A repository must match at least one entry to be processed. An explicit empty list (`[]`) processes **no** repositories — a fail-closed "pause everything" lever. |
 | `exclude_patterns` | array of strings | `[]` | Glob patterns that take precedence over `include_patterns`. A repository matching an exclude pattern is never processed, even if it also matches an include pattern. |
 
 **Behaviour when the section is absent:** every repository the GitHub App is installed on

--- a/docs/user/reference/environment-variables.md
+++ b/docs/user/reference/environment-variables.md
@@ -16,7 +16,7 @@ clear error message if a required variable is absent.
 | :--- | :--- |
 | `MERGE_WARDEN_GITHUB_APP_ID` | Numeric GitHub App ID shown on the App settings page |
 | `MERGE_WARDEN_GITHUB_APP_PRIVATE_KEY` | Full PEM-encoded private key as an inline string (not a file path) |
-| `GITHUB_WEBHOOK_SECRET` | Webhook signing secret configured in the GitHub App webhook settings |
+| `GITHUB_WEBHOOK_SECRET` | Webhook signing secret configured in the GitHub App webhook settings. **Required only in `webhook` receiver mode.** In `queue` mode this variable is not read — Merge Warden never receives a webhook payload directly in that mode, so it never validates a signature. See [Receiver modes](../explanation/receiver-modes.md). |
 
 ---
 
@@ -27,6 +27,31 @@ clear error message if a required variable is absent.
 | `MERGE_WARDEN_PORT` | `3000` | TCP port the HTTP server listens on |
 | `MERGE_WARDEN_RECEIVER_MODE` | `webhook` | Event receiver mode: `webhook` or `queue`. See [Receiver modes](../explanation/receiver-modes.md). |
 | `MERGE_WARDEN_CONFIG_FILE` | *(none)* | Absolute path to a TOML application-level policy config file mounted into the container. See [Set application-level defaults](../how-to/set-app-level-defaults.md). |
+
+---
+
+## Required and optional — Queue mode only
+
+These variables are only read when `MERGE_WARDEN_RECEIVER_MODE=queue`. In `queue` mode,
+Merge Warden is a pure queue consumer — a separate service is responsible for receiving
+the GitHub webhook, verifying its signature, and enqueueing the message. See
+[Receiver modes](../explanation/receiver-modes.md) and
+[How to run Merge Warden in queue mode](../how-to/run-in-queue-mode.md).
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `MERGE_WARDEN_QUEUE_PROVIDER` | *(required)* | Queue backend to consume from: `azure`, `aws`, or `memory` (in-memory — local testing only, not durable). |
+| `MERGE_WARDEN_QUEUE_NAME` | `merge-warden-events` | Name of the queue to consume from. |
+| `MERGE_WARDEN_QUEUE_CONCURRENCY` | `4` | Maximum number of in-flight messages processed concurrently. |
+| `AZURE_SERVICEBUS_NAMESPACE` | *(required if `MERGE_WARDEN_QUEUE_PROVIDER=azure`)* | Azure Service Bus namespace. Authentication uses the default Azure credential chain (managed identity, `az login`, etc.) — there is no connection-string variable. |
+| `AWS_REGION` | `us-east-1` | AWS region for SQS, when `MERGE_WARDEN_QUEUE_PROVIDER=aws`. |
+| `AWS_ACCESS_KEY_ID` | *(none)* | Optional static AWS credential, when `MERGE_WARDEN_QUEUE_PROVIDER=aws`. Prefer an IAM role (ECS task role, IRSA, instance profile) in production instead of static keys. |
+| `AWS_SECRET_ACCESS_KEY` | *(none)* | Optional static AWS credential, paired with `AWS_ACCESS_KEY_ID`. Same production guidance as above. |
+
+Any `MERGE_WARDEN_QUEUE_PROVIDER` value other than `azure`, `aws`, or `memory` fails
+startup with a configuration error. The underlying `queue-runtime` library also supports
+NATS and RabbitMQ, but Merge Warden does not yet expose `nats`/`rabbitmq` as provider
+values — this is planned, not currently available.
 
 ---
 
@@ -61,3 +86,5 @@ clear error message if a required variable is absent.
 - [Deploy on Azure](../how-to/deploy-on-azure.md)
 - [Deploy on AWS](../how-to/deploy-on-aws.md)
 - [Set application-level defaults](../how-to/set-app-level-defaults.md)
+- [Run Merge Warden in queue mode](../how-to/run-in-queue-mode.md)
+- [Webhook vs queue receiver modes](../explanation/receiver-modes.md)

--- a/docs/user/reference/http-endpoints.md
+++ b/docs/user/reference/http-endpoints.md
@@ -5,7 +5,13 @@ description: "HTTP endpoints exposed by the Merge Warden server."
 
 # HTTP endpoints reference
 
-The Merge Warden server exposes two HTTP endpoints on the configured port (default `3000`).
+The Merge Warden server exposes up to two HTTP endpoints on the configured port (default
+`3000`), depending on `MERGE_WARDEN_RECEIVER_MODE`.
+
+- In **`webhook` mode** (the default), both endpoints below are registered.
+- In **`queue` mode**, only `GET /health` is registered. `POST /api/github/webhook` does not
+  exist in this mode — Merge Warden is a pure queue consumer and never receives a webhook
+  payload directly. See [Webhook vs queue receiver modes](../explanation/receiver-modes.md).
 
 ---
 
@@ -70,6 +76,12 @@ All other event types are acknowledged with `202 Accepted` and discarded.
 For `pull_request` events, only the following actions trigger processing:
 `opened`, `edited`, `ready_for_review`, `reopened`, `unlocked`, `synchronize`.
 
+If `[policies.repository_scope]` is configured in the application-level config, events for
+repositories outside the configured scope are also acknowledged without any further
+processing — regardless of event type or action — and without any GitHub API call being
+made on behalf of that repository. See
+[Configure repository scope filtering](../how-to/configure-repository-scope.md).
+
 ---
 
 ## Related
@@ -77,3 +89,4 @@ For `pull_request` events, only the following actions trigger processing:
 - [Environment variables reference](environment-variables.md)
 - [GitHub App permissions](github-app-permissions.md)
 - [Webhook vs queue receiver modes](../explanation/receiver-modes.md)
+- [Configure repository scope filtering](../how-to/configure-repository-scope.md)

--- a/docs/user/reference/per-repo-config.md
+++ b/docs/user/reference/per-repo-config.md
@@ -141,11 +141,9 @@ pending_stability_label = "pr-validation: pending-stability"
 | `pending_stability_label` | string | `"pr-validation: pending-stability"` | Label applied while the `renovate/stability-days` status is `pending`, `error`, or `failure`. |
 
 > **Note:** The label is purely informational and never affects the Merge Warden check
-> result. The merge rule for `enabled` is OR: once either tier enables this feature it
-> stays enabled. To disable it for a specific repository, set `enabled = false` explicitly
-> in that repository's `.github/merge-warden.toml`. Setting `enabled = false` in the
-> application-level configuration only suppresses the feature for repositories that have
-> no per-repo config file.
+> result. `enabled` merges via OR rather than plain override — see
+> [Configuration precedence — the Renovate-stability `enabled` merge rule](../explanation/config-precedence.md#exception-the-renovate-stability-enabled-merge-rule-is-or-not-override)
+> for the full explanation and how to disable the feature for a specific repository.
 
 ---
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -29,6 +29,12 @@ Pass it to `run-local.ps1` with:
 .\samples\run-local.ps1 -Repo "owner/repo" -AppConfigFile ".\samples\app-config.sample.toml"
 ```
 
+The file includes a commented-out `[policies.repository_scope]` block for restricting
+which repositories this server instance actively processes (independent of which
+repositories the GitHub App installation can access). See
+[docs/user/how-to/configure-repository-scope.md](../docs/user/how-to/configure-repository-scope.md)
+for the allow-list and fail-closed "pause everything" examples.
+
 ---
 
 ## merge-warden.sample.toml — per-repository config

--- a/samples/app-config.sample.toml
+++ b/samples/app-config.sample.toml
@@ -57,6 +57,15 @@ ignore_deletions = false
 label_prefix = "size/"
 add_comment = true
 
+# Optional: Custom size thresholds (uncomment to override the built-in defaults).
+# [policies.pr_size_check.thresholds]
+# xs = 10    # 1-10 lines
+# s = 50     # 11-50 lines
+# m = 100    # 51-100 lines
+# l = 250    # 101-250 lines
+# xl = 500   # 251-500 lines
+# xxl = 501+ lines (anything above xl)
+
 # WIP detection — disabled by default at app level.
 [policies.wip_check]
 enforce_wip_blocking = true
@@ -71,6 +80,69 @@ draft_label = "status: draft"
 review_label = "status: in-review"
 approved_label = "status: approved"
 
+# Renovate stability-days label management — reflects the state of the
+# Renovate `renovate/stability-days` commit-status check as a label. Purely
+# informational: never blocks merging or affects the check conclusion.
+[policies.renovate_stability]
+# Once enabled here or by any repository, the feature stays enabled — a repo
+# cannot set `enabled = false` to opt back out. To disable for every
+# repository, set `enabled = false` here and do not enable it per-repo.
+enabled = true
+pending_stability_label = "pr-validation: pending-stability"
+
+# Change-type label detection — maps conventional-commit types to
+# repository-specific labels, applied to every repository unless overridden
+# by its own .github/merge-warden.toml.
+[policies.change_type_labels]
+enabled = true
+
+[policies.change_type_labels.conventional_commit_mappings]
+feat = ["enhancement", "feature"]
+fix = ["bug", "bugfix"]
+docs = ["documentation"]
+style = ["style", "formatting"]
+refactor = ["refactor", "refactoring"]
+perf = ["performance", "optimization"]
+test = ["test", "tests", "testing"]
+chore = ["chore", "maintenance"]
+ci = ["ci", "continuous integration"]
+build = ["build", "dependencies"]
+revert = ["revert"]
+
+[policies.change_type_labels.fallback_label_settings]
+# Template for created label names. Use {change_type} as a placeholder.
+name_format = "type: {change_type}"
+# When true, a new repository label is created if no existing label matches.
+create_if_missing = true
+
+[policies.change_type_labels.fallback_label_settings.color_scheme]
+feat = "#0075ca"
+fix = "#d73a4a"
+docs = "#0052cc"
+style = "#f9d0c4"
+refactor = "#fef2c0"
+perf = "#a2eeef"
+test = "#d4edda"
+chore = "#e1e4e8"
+ci = "#fbca04"
+build = "#c5def5"
+revert = "#b60205"
+
+[policies.change_type_labels.detection_strategy]
+exact_match = true
+prefix_match = true
+description_match = true
+common_prefixes = ["type:", "kind:", "category:"]
+
+# Labels applied based on keywords in the PR title or body, independent of the
+# conventional-commit type. All fields are optional; omitted fields fall back
+# to the built-in defaults shown below.
+[policies.change_type_labels.keyword_labels]
+breaking_change = "breaking-change"
+security = "security"
+hotfix = "hotfix"
+tech_debt = "tech-debt"
+
 # Bypass rules — allow specific GitHub usernames to skip validations.
 [policies.bypass_rules.title_convention]
 enabled = false
@@ -83,3 +155,17 @@ users = []
 [policies.bypass_rules.size]
 enabled = false
 users = []
+
+# Repository scope filtering — restricts which repositories this server
+# instance actively processes, independent of which repositories the GitHub
+# App installation can technically access. Useful for large orgs where GitHub
+# only offers "All repositories" as an install-scope option.
+#
+# Omit this section entirely to process every repository the GitHub App is
+# installed on (the pre-existing, backward-compatible behaviour). An explicit
+# empty include_patterns list is a fail-closed "pause everything" lever.
+# See docs/user/how-to/configure-repository-scope.md for details.
+#
+# [policies.repository_scope]
+# include_patterns = ["payments-*", "checkout", "billing-?"]
+# exclude_patterns = ["payments-legacy"]

--- a/samples/merge-warden-org-policy.sample.toml
+++ b/samples/merge-warden-org-policy.sample.toml
@@ -72,12 +72,25 @@ label_if_missing = "pr-issue: invalid-title-format"
 # sync_milestone_from_issue = true
 # sync_project_from_issue   = true
 
+# Uncomment to force Renovate stability-days label management on for every
+# repo in the org. Note the merge rule is OR: an enforced `enabled = true`
+# cannot be turned off by any lower tier, but an enforced `enabled = false`
+# also cannot turn off a `true` set by a lower tier — use [defaults] instead
+# if you want repos to be able to opt in/out.
+# [enforced.policies.pullRequests.renovateStability]
+# enabled = true
+# pending_stability_label = "pr-validation: pending-stability"
+
 # Uncomment to enforce bot bypasses org-wide (repos cannot remove these users from the bypass list).
 # [enforced.policies.bypassRules.title_convention]
 # enabled = true
 # users   = ["renovate[bot]", "dependabot[bot]"]
 #
 # [enforced.policies.bypassRules.work_items]
+# enabled = true
+# users   = ["renovate[bot]", "dependabot[bot]"]
+#
+# [enforced.policies.bypassRules.size]
 # enabled = true
 # users   = ["renovate[bot]", "dependabot[bot]"]
 
@@ -126,6 +139,13 @@ xl = 500
 # [defaults.policies.pullRequests.issuePropagation]
 # sync_milestone_from_issue = false
 # sync_project_from_issue   = false
+
+# Org-wide default for Renovate stability-days label management. Repos may
+# still enable this even when it is off here (the merge rule is OR), but
+# cannot disable it once any tier has set `enabled = true`.
+# [defaults.policies.pullRequests.renovateStability]
+# enabled = true
+# pending_stability_label = "pr-validation: pending-stability"
 
 # Change-type label defaults at org level.
 # Repos may override individual label names or the fallback settings.

--- a/samples/merge-warden.sample.toml
+++ b/samples/merge-warden.sample.toml
@@ -143,24 +143,10 @@ pending_stability_label = "pr-validation: pending-stability"
 # enabled = true
 # users = ["renovate[bot]", "dependabot[bot]"]
 
-# Repository scope filtering — restricts which repositories Merge Warden
-# actively processes, independent of which repositories the GitHub App
-# installation can technically reach (relevant for large organisations
-# forced to install with "All repositories" scope).
-#
-# Omit this entire section to process every repository the installation
-# receives webhooks for (default, full backward compatibility).
-# [policies.repository_scope]
-# Glob patterns (`*` = any sequence, `?` = single character) matched
-# case-insensitively against the bare repository name. A repository must
-# match at least one entry to be processed. Setting this to an empty list
-# ([]) is a deliberate fail-closed "pause everything" lever.
-# include_patterns = ["payments-*", "checkout", "billing-?"]
-
-# Glob patterns that take precedence over include_patterns — a repository
-# matching an exclude pattern is never processed, even if it also matches
-# an include pattern. Defaults to an empty list when omitted.
-# exclude_patterns = ["payments-legacy"]
+# Repository scope filtering (which repositories Merge Warden actively
+# processes) is an application-level-only setting — it cannot be configured
+# here. Setting [policies.repository_scope] in this file has no effect; it is
+# silently ignored at parse time. See app-config.sample.toml instead.
 
 # Configuration for smart change type label detection
 [change_type_labels]

--- a/samples/merge-warden.sample.toml
+++ b/samples/merge-warden.sample.toml
@@ -114,6 +114,35 @@ enabled = false
 # Label applied when the PR has at least one approving review.
 # approved_label = "status: approved"
 
+# Renovate stability-days label management — reflects the state of the
+# Renovate `renovate/stability-days` commit-status check as a label, so
+# reviewers see at a glance whether the stability period has elapsed.
+# Purely informational: never blocks merging or affects the check conclusion.
+[policies.pullRequests.renovateStability]
+# Once enabled by either this repo or the app-level default, the feature stays
+# enabled — a repo cannot use `enabled = false` to opt back out of an
+# app-level `enabled = true`. To disable everywhere, set it at the app level.
+enabled = true
+
+# Label applied while the stability period has not yet elapsed. Removed
+# automatically once the Renovate check reports success.
+pending_stability_label = "pr-validation: pending-stability"
+
+# Bypass rules — allow specific GitHub usernames to skip validations for this
+# repository. Uncomment to add or override a bypass list; omitted sub-tables
+# fall back to whatever the app-level or org-level defaults specify.
+# [policies.bypassRules.title_convention]
+# enabled = true
+# users = ["release-bot"]
+#
+# [policies.bypassRules.work_items]
+# enabled = true
+# users = ["release-bot"]
+#
+# [policies.bypassRules.size]
+# enabled = true
+# users = ["renovate[bot]", "dependabot[bot]"]
+
 # Repository scope filtering — restricts which repositories Merge Warden
 # actively processes, independent of which repositories the GitHub App
 # installation can technically reach (relevant for large organisations
@@ -182,6 +211,15 @@ chore = "#e1e4e8"    # Light gray - maintenance
 ci = "#fbca04"       # Yellow - CI/CD
 build = "#c5def5"    # Light blue - build system
 revert = "#b60205"   # Dark red - reverts
+
+# Labels applied based on keywords found in the PR title or body, independent
+# of the conventional-commit type. All fields are optional; omitted fields
+# fall back to the built-in defaults shown below.
+[change_type_labels.keyword_labels]
+breaking_change = "breaking-change"   # PR title contains `!:` or body contains "breaking change"
+security = "security"                 # PR body contains "security" or "vulnerability"
+hotfix = "hotfix"                     # PR body contains "hotfix"
+tech_debt = "tech-debt"               # PR body contains "technical debt" or "tech debt"
 
 # Configuration for the label detection strategy
 [change_type_labels.detection_strategy]


### PR DESCRIPTION
## Summary

- Documents repository scope filtering (FR-009, shipped in #331) for the first time: new how-to guide, `reference/app-config.md` field docs, and a callout in `config-precedence.md` that scope filtering runs *before* the config-merge chain (an excluded repo's own `.github/merge-warden.toml` is never fetched).
- Corrects the queue receiver mode docs, which described an architecture that never shipped (a single process both receiving the webhook and consuming the queue). Queue mode is actually a pure consumer exposing only `GET /health`; a separate service must own webhook receipt, HMAC validation, and enqueueing. Added a new how-to guide for operating it, and documented the queue-mode env vars (including that `MERGE_WARDEN_QUEUE_PROVIDER` currently only supports `azure`/`aws`/`memory` — NATS/RabbitMQ are supported by the underlying `queue-runtime` library but not yet wired up).
- Brings the `samples/*.toml` files back in sync with the actual config schema: Renovate stability-days settings, change-type `keyword_labels`, and per-repo/org bypass rules were missing from one or more sample files even though they're valid config fields.
- Drops stale "Azure Functions" wording from `docs/spec/requirements/functional-requirements.md` FR-006 now that the server ships as a container (Azure Container Apps / AWS ECS).
- Minor Diataxis cleanup: trimmed content duplicated across how-to and reference pages (bypass-rules security notes, Renovate OR-merge-rule explanation) to a single source of truth.

## Test plan

- [x] All three sample TOML files parse successfully (validated with Python's `tomllib`)
- [x] New/changed field names and behavior cross-checked against `crates/core/src/config.rs` and `crates/server/src/config.rs` (not just the spec docs, which had also drifted in places)
- [ ] Docs review — Diataxis categorization and prose clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)