### PR TITLE
fix(config): correct org_policy_source nesting in docs, ADR, and samples

### DIFF
--- a/crates/cli/src/config_tests.rs
+++ b/crates/cli/src/config_tests.rs
@@ -11,7 +11,8 @@ use super::*;
 // `[org_policy_source]` table, because `AppConfig` only maps the file's `[policies]`
 // table onto `ApplicationDefaults`. A regression here silently disables org-level
 // policy resolution with no load error and no runtime log line — see
-// .llm/patch-org-policy-app-config.md for the production incident this caused.
+// ADR-003 (docs/adr/ADR-003-org-level-policy.md) for background, and PR #335
+// for the production incident this caused.
 // ---------------------------------------------------------------------------
 
 fn temp_path(name: &str) -> PathBuf {
@@ -58,11 +59,12 @@ fn load_reads_valid_org_policy_source_from_toml_file() {
     assert!(source.fail_if_unreachable);
 }
 
-/// Regression test for the production incident documented in
-/// `.llm/patch-org-policy-app-config.md`: a top-level `[org_policy_source]` table
-/// (rather than `[policies.org_policy_source]`) is silently ignored by the TOML
-/// parser and must not populate `ApplicationDefaults.org_policy_source`, nor cause
-/// `AppConfig::load` to fail — the file is otherwise valid TOML.
+/// Regression test for the production incident described in ADR-003
+/// (docs/adr/ADR-003-org-level-policy.md) and PR #335: a top-level
+/// `[org_policy_source]` table (rather than `[policies.org_policy_source]`) is
+/// silently ignored by the TOML parser and must not populate
+/// `ApplicationDefaults.org_policy_source`, nor cause `AppConfig::load` to fail —
+/// the file is otherwise valid TOML.
 #[test]
 fn load_ignores_top_level_org_policy_source_table() {
     let path = temp_path("merge_warden_cli_top_level_org_policy_source_test.toml");

--- a/crates/cli/src/config_tests.rs
+++ b/crates/cli/src/config_tests.rs
@@ -1,1 +1,87 @@
-// Nothing here at the moment
+use std::path::PathBuf;
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// AppConfig::load — org_policy_source (ADR-003: Org-Level Policy Configuration)
+//
+// `org_policy_source` is a field on `merge_warden_core::config::ApplicationDefaults`,
+// exactly like every other field under `[policies]` in this file's `AppConfig::policies`.
+// It must be nested under `[policies.org_policy_source]`, not a top-level
+// `[org_policy_source]` table, because `AppConfig` only maps the file's `[policies]`
+// table onto `ApplicationDefaults`. A regression here silently disables org-level
+// policy resolution with no load error and no runtime log line — see
+// .llm/patch-org-policy-app-config.md for the production incident this caused.
+// ---------------------------------------------------------------------------
+
+fn temp_path(name: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(name);
+    path
+}
+
+#[test]
+fn load_defaults_org_policy_source_to_none_when_absent_from_file() {
+    let path = temp_path("merge_warden_cli_no_org_policy_source_test.toml");
+    std::fs::write(&path, "[policies]\nenable_title_validation = true\n").unwrap();
+
+    let r = AppConfig::load(&path);
+    let _ = std::fs::remove_file(&path);
+
+    let config = r.expect("AppConfig::load should succeed");
+    assert!(
+        config.policies.org_policy_source.is_none(),
+        "org_policy_source must default to None when not present in the file"
+    );
+}
+
+#[test]
+fn load_reads_valid_org_policy_source_from_toml_file() {
+    let path = temp_path("merge_warden_cli_valid_org_policy_source_test.toml");
+    std::fs::write(
+        &path,
+        "[policies.org_policy_source]\nowner = \"my-org\"\nrepo = \"platform-configs\"\npath = \"merge-warden/org-policy.toml\"\nfail_if_unreachable = true\n",
+    )
+    .unwrap();
+
+    let r = AppConfig::load(&path);
+    let _ = std::fs::remove_file(&path);
+
+    let config = r.expect("AppConfig::load should succeed");
+    let source = config
+        .policies
+        .org_policy_source
+        .expect("org_policy_source should be Some when [policies.org_policy_source] is present");
+    assert_eq!(source.owner, "my-org");
+    assert_eq!(source.repo, "platform-configs");
+    assert_eq!(source.path, "merge-warden/org-policy.toml");
+    assert!(source.fail_if_unreachable);
+}
+
+/// Regression test for the production incident documented in
+/// `.llm/patch-org-policy-app-config.md`: a top-level `[org_policy_source]` table
+/// (rather than `[policies.org_policy_source]`) is silently ignored by the TOML
+/// parser and must not populate `ApplicationDefaults.org_policy_source`, nor cause
+/// `AppConfig::load` to fail — the file is otherwise valid TOML.
+#[test]
+fn load_ignores_top_level_org_policy_source_table() {
+    let path = temp_path("merge_warden_cli_top_level_org_policy_source_test.toml");
+    std::fs::write(
+        &path,
+        "[org_policy_source]\nowner = \"my-org\"\nrepo = \"platform-configs\"\npath = \"merge-warden/org-policy.toml\"\n\n[policies]\nenable_title_validation = true\n",
+    )
+    .unwrap();
+
+    let r = AppConfig::load(&path);
+    let _ = std::fs::remove_file(&path);
+
+    let config = r.expect("AppConfig::load should succeed");
+    assert!(
+        config.policies.org_policy_source.is_none(),
+        "a top-level [org_policy_source] table must not populate ApplicationDefaults.org_policy_source"
+    );
+    assert!(
+        config.policies.enable_title_validation,
+        "the [policies] table alongside the misplaced top-level table should still load normally"
+    );
+}

--- a/crates/server/src/config_tests.rs
+++ b/crates/server/src/config_tests.rs
@@ -475,6 +475,115 @@ fn load_config_returns_config_error_for_malformed_toml() {
 }
 
 // ---------------------------------------------------------------------------
+// load_config — org_policy_source (ADR-003: Org-Level Policy Configuration)
+//
+// `org_policy_source` is a field on `ApplicationDefaults`, exactly like
+// `repository_scope` below. It must be nested under `[policies.org_policy_source]`
+// in the file, not a top-level `[org_policy_source]` table, because `load_config`
+// only maps the file's `[policies]` table onto `ApplicationDefaults`
+// (see `ServerTomlConfig` above). A regression here silently disables org-level
+// policy resolution with no startup error and no runtime log line — see
+// .llm/patch-org-policy-app-config.md for the production incident this caused.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn load_config_defaults_org_policy_source_to_none_when_config_file_absent() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+    let _env = EnvGuard::prepare(
+        &[],
+        &[
+            "MERGE_WARDEN_PORT",
+            "MERGE_WARDEN_RECEIVER_MODE",
+            "MERGE_WARDEN_CONFIG_FILE",
+        ],
+    );
+
+    let r = load_config();
+    assert!(r.is_ok(), "{:?}", r);
+    assert!(
+        r.unwrap().application_defaults.org_policy_source.is_none(),
+        "org_policy_source must default to None when no config file is provided"
+    );
+}
+
+#[test]
+fn load_config_reads_valid_org_policy_source_from_toml_file() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+    let mut path = std::env::temp_dir();
+    path.push("merge_warden_server_valid_org_policy_source_test.toml");
+    std::fs::write(
+        &path,
+        "[policies.org_policy_source]\nowner = \"my-org\"\nrepo = \"platform-configs\"\npath = \"merge-warden/org-policy.toml\"\nfail_if_unreachable = true\n",
+    )
+    .unwrap();
+
+    let _env = EnvGuard::prepare(
+        &[("MERGE_WARDEN_CONFIG_FILE", path.to_str().unwrap())],
+        &[
+            "MERGE_WARDEN_PORT",
+            "MERGE_WARDEN_RECEIVER_MODE",
+            "MERGE_WARDEN_CONFIG_FILE",
+        ],
+    );
+
+    let r = load_config();
+    let _ = std::fs::remove_file(&path);
+
+    assert!(r.is_ok(), "{:?}", r);
+    let source = r
+        .unwrap()
+        .application_defaults
+        .org_policy_source
+        .expect("org_policy_source should be Some when [policies.org_policy_source] is present");
+    assert_eq!(source.owner, "my-org");
+    assert_eq!(source.repo, "platform-configs");
+    assert_eq!(source.path, "merge-warden/org-policy.toml");
+    assert!(source.fail_if_unreachable);
+}
+
+/// Regression test for the production incident documented in
+/// `.llm/patch-org-policy-app-config.md`: a top-level `[org_policy_source]` table
+/// (rather than `[policies.org_policy_source]`) is silently ignored by the TOML
+/// parser and must not populate `ApplicationDefaults.org_policy_source`, nor cause
+/// `load_config` to fail — the file is otherwise valid TOML.
+#[test]
+fn load_config_ignores_top_level_org_policy_source_table() {
+    let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+    let mut path = std::env::temp_dir();
+    path.push("merge_warden_server_top_level_org_policy_source_test.toml");
+    std::fs::write(
+        &path,
+        "[org_policy_source]\nowner = \"my-org\"\nrepo = \"platform-configs\"\npath = \"merge-warden/org-policy.toml\"\n\n[policies]\nenable_title_validation = true\n",
+    )
+    .unwrap();
+
+    let _env = EnvGuard::prepare(
+        &[("MERGE_WARDEN_CONFIG_FILE", path.to_str().unwrap())],
+        &[
+            "MERGE_WARDEN_PORT",
+            "MERGE_WARDEN_RECEIVER_MODE",
+            "MERGE_WARDEN_CONFIG_FILE",
+        ],
+    );
+
+    let r = load_config();
+    let _ = std::fs::remove_file(&path);
+
+    assert!(r.is_ok(), "{:?}", r);
+    let defaults = r.unwrap().application_defaults;
+    assert!(
+        defaults.org_policy_source.is_none(),
+        "a top-level [org_policy_source] table must not populate ApplicationDefaults.org_policy_source"
+    );
+    assert!(
+        defaults.enable_title_validation,
+        "the [policies] table alongside the misplaced top-level table should still load normally"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // load_config — repository_scope (FR-009: Repository Scope Filtering)
 //
 // See docs/spec/interfaces/server-config.md and

--- a/crates/server/src/config_tests.rs
+++ b/crates/server/src/config_tests.rs
@@ -483,7 +483,8 @@ fn load_config_returns_config_error_for_malformed_toml() {
 // only maps the file's `[policies]` table onto `ApplicationDefaults`
 // (see `ServerTomlConfig` above). A regression here silently disables org-level
 // policy resolution with no startup error and no runtime log line — see
-// .llm/patch-org-policy-app-config.md for the production incident this caused.
+// ADR-003 (docs/adr/ADR-003-org-level-policy.md) for background, and PR #335
+// for the production incident this caused.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -542,11 +543,12 @@ fn load_config_reads_valid_org_policy_source_from_toml_file() {
     assert!(source.fail_if_unreachable);
 }
 
-/// Regression test for the production incident documented in
-/// `.llm/patch-org-policy-app-config.md`: a top-level `[org_policy_source]` table
-/// (rather than `[policies.org_policy_source]`) is silently ignored by the TOML
-/// parser and must not populate `ApplicationDefaults.org_policy_source`, nor cause
-/// `load_config` to fail — the file is otherwise valid TOML.
+/// Regression test for the production incident described in ADR-003
+/// (docs/adr/ADR-003-org-level-policy.md) and PR #335: a top-level
+/// `[org_policy_source]` table (rather than `[policies.org_policy_source]`) is
+/// silently ignored by the TOML parser and must not populate
+/// `ApplicationDefaults.org_policy_source`, nor cause `load_config` to fail —
+/// the file is otherwise valid TOML.
 #[test]
 fn load_config_ignores_top_level_org_policy_source_table() {
     let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());

--- a/crates/server/src/config_tests.rs
+++ b/crates/server/src/config_tests.rs
@@ -532,11 +532,10 @@ fn load_config_reads_valid_org_policy_source_from_toml_file() {
     let _ = std::fs::remove_file(&path);
 
     assert!(r.is_ok(), "{:?}", r);
-    let source = r
-        .unwrap()
-        .application_defaults
-        .org_policy_source
-        .expect("org_policy_source should be Some when [policies.org_policy_source] is present");
+    let source =
+        r.unwrap().application_defaults.org_policy_source.expect(
+            "org_policy_source should be Some when [policies.org_policy_source] is present",
+        );
     assert_eq!(source.owner, "my-org");
     assert_eq!(source.repo, "platform-configs");
     assert_eq!(source.path, "merge-warden/org-policy.toml");

--- a/docs/adr/ADR-003-org-level-policy.md
+++ b/docs/adr/ADR-003-org-level-policy.md
@@ -4,6 +4,12 @@ Status: Accepted
 Date: 2026-05-28
 Owners: merge_warden team
 
+> **Errata (2026-07-16, PR #335):** The TOML example in Decision 1 originally showed
+> `[org_policy_source]` (top-level). The correct form is `[policies.org_policy_source]`,
+> since `OrgPolicySource` is a field on `ApplicationDefaults`, which only maps from the
+> file's `[policies]` table. This document has been corrected in place; see PR #335 for
+> the production incident this caused.
+
 ## Context
 
 Task 5.0 adds a fourth configuration tier to Merge Warden: a designated org-wide policy repository

--- a/docs/adr/ADR-003-org-level-policy.md
+++ b/docs/adr/ADR-003-org-level-policy.md
@@ -40,7 +40,7 @@ The four open decisions for this ADR are:
 `OrgPolicySource` is added as an optional field on `ApplicationDefaults`:
 
 ```toml
-[org_policy_source]
+[policies.org_policy_source]
 owner = "my-org"
 repo  = "org-configs"
 path  = "merge-warden-org-policy.toml"
@@ -328,7 +328,7 @@ A repo with no `workItem` config will inherit the org default `JIRA-\\d+`.
 `app-config.toml`:
 
 ```toml
-[org_policy_source]
+[policies.org_policy_source]
 owner = "my-org"
 repo  = "platform-configs"
 path  = "merge-warden/org-policy.toml"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,11 +126,11 @@ See `samples/app-config.sample.toml`.
 
 #### Tier 2 — Org Defaults (optional)
 
-Fetched from a central repository at runtime using the `[org_policy_source]` field
+Fetched from a central repository at runtime using the `[policies.org_policy_source]` field
 in the app-level config:
 
 ```toml
-[org_policy_source]
+[policies.org_policy_source]
 owner = "my-org"
 repo  = "platform-configs"
 path  = "merge-warden/org-policy.toml"

--- a/docs/spec/architecture/org-policy-config.md
+++ b/docs/spec/architecture/org-policy-config.md
@@ -193,14 +193,19 @@ flags are removed from this function — they now live in `resolve_pull_request_
 ```toml
 # app-config.toml — new optional section
 
-[org_policy_source]
+[policies.org_policy_source]
 owner              = "my-org"
 repo               = "platform-configs"
 path               = "merge-warden/org-policy.toml"
 # fail_if_unreachable = false   # optional; default false
 ```
 
-When `[org_policy_source]` is absent, `ApplicationDefaults.org_policy_source` is `None` and
+`org_policy_source` is a field on `ApplicationDefaults`, so — like every other field on that
+struct — it is only recognized when nested under `[policies]` in the file the server/CLI
+loader wraps `ApplicationDefaults` with. A top-level `[org_policy_source]` table is silently
+ignored.
+
+When `[policies.org_policy_source]` is absent, `ApplicationDefaults.org_policy_source` is `None` and
 the system behaves identically to the previous release.
 
 ---

--- a/docs/spec/interfaces/org-policy.md
+++ b/docs/spec/interfaces/org-policy.md
@@ -27,12 +27,17 @@ stated otherwise.
 /// # TOML example
 ///
 /// ```toml
-/// [org_policy_source]
+/// [policies.org_policy_source]
 /// owner = "my-org"
 /// repo  = "platform-configs"
 /// path  = "merge-warden/org-policy.toml"
 /// # fail_if_unreachable = false   # optional; default false
 /// ```
+///
+/// Note the `[policies.*]` nesting: `org_policy_source` is a field on
+/// `ApplicationDefaults`, and the server/CLI config loaders only map the file's
+/// `[policies]` table onto `ApplicationDefaults`. A top-level `[org_policy_source]`
+/// table is silently ignored.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct OrgPolicySource {
     /// GitHub organisation or user name that owns the policy repository.

--- a/docs/user/explanation/config-precedence.md
+++ b/docs/user/explanation/config-precedence.md
@@ -21,7 +21,7 @@ MERGE_WARDEN_CONFIG_FILE (application defaults)
 Compiled-in defaults                         ← lowest priority
 ```
 
-The org-level policy tier is optional. When `[org_policy_source]` is not configured in
+The org-level policy tier is optional. When `[policies.org_policy_source]` is not configured in
 the application config, the system uses the three-tier model (application defaults →
 per-repository config → compiled-in defaults).
 
@@ -81,7 +81,7 @@ See [Application configuration schema](../reference/app-config.md) and
 
 ### Layer 3 — Org-level policy (optional)
 
-When `[org_policy_source]` is configured in the application-level config, the server
+When `[policies.org_policy_source]` is configured in the application-level config, the server
 fetches a central org policy TOML file on every PR event. This file has two sections:
 
 - **`[defaults]`** — org-wide defaults that individual repositories *can* override with

--- a/docs/user/how-to/configure-org-policy.md
+++ b/docs/user/how-to/configure-org-policy.md
@@ -59,11 +59,11 @@ for an annotated example covering enforced, default, and conditional policy sect
 
 ## Step 3: Point the server at the org policy file
 
-Add `[org_policy_source]` to the application-level configuration file
+Add `[policies.org_policy_source]` to the application-level configuration file
 (`MERGE_WARDEN_CONFIG_FILE`):
 
 ```toml
-[org_policy_source]
+[policies.org_policy_source]
 owner = "my-org"
 repo  = "platform-configs"
 path  = "merge-warden/org-policy.toml"
@@ -164,7 +164,7 @@ infrastructure problem that the operator may want to surface explicitly.
 
 ## Related
 
-- [Application configuration schema — org_policy_source](../reference/app-config.md#org_policy_source)
+- [Application configuration schema — org_policy_source](../reference/app-config.md#policiesorg_policy_source)
 - [Configuration precedence](../explanation/config-precedence.md)
 - [Set application-level policy defaults](set-app-level-defaults.md)
 - [Per-repository configuration schema](../reference/per-repo-config.md)

--- a/docs/user/reference/app-config.md
+++ b/docs/user/reference/app-config.md
@@ -131,7 +131,7 @@ and [Per-repository configuration schema — renovateStability](per-repo-config.
 
 ---
 
-## `[org_policy_source]`
+## `[policies.org_policy_source]`
 
 Optional. When present, the server fetches a central org-level policy TOML file on
 every PR event and inserts it into the configuration resolution chain.
@@ -146,7 +146,7 @@ every PR event and inserts it into the configuration resolution chain.
 **Example:**
 
 ```toml
-[org_policy_source]
+[policies.org_policy_source]
 owner               = "my-org"
 repo                = "platform-configs"
 path                = "merge-warden/org-policy.toml"
@@ -213,7 +213,7 @@ worked examples and pattern syntax details.
 
 ```toml
 # Optional — enable org-level policy from a central repository.
-# [org_policy_source]
+# [policies.org_policy_source]
 # owner               = "my-org"
 # repo                = "platform-configs"
 # path                = "merge-warden/org-policy.toml"

--- a/samples/app-config.sample.toml
+++ b/samples/app-config.sample.toml
@@ -22,7 +22,12 @@
 #
 # See samples/merge-warden-org-policy.sample.toml for the format of that file.
 #
-# [org_policy_source]
+# org_policy_source is a field on ApplicationDefaults, the same struct as every
+# field under [policies] below — it must be nested the same way. A top-level
+# [org_policy_source] table is silently ignored (no error, no warning), which
+# leaves org policy resolution permanently skipped.
+#
+# [policies.org_policy_source]
 # owner = "my-org"
 # repo  = "platform-configs"
 # path  = "merge-warden/org-policy.toml"


### PR DESCRIPTION
## Summary

- `org_policy_source` is a field on `ApplicationDefaults`, deserialized the same way as `bot_mention`, `pr_size_check`, `wip_check`, etc. — the server (`crates/server/src/config.rs`) and CLI (`crates/cli/src/config.rs`) loaders only map the file's `[policies]` table onto `ApplicationDefaults`, so it must be written as `[policies.org_policy_source]`.
- ADR-003, the app-config reference doc, the org-policy how-to guide, `docs/architecture.md`, `docs/spec/architecture/org-policy-config.md`, `docs/spec/interfaces/org-policy.md`, and `samples/app-config.sample.toml` all showed it as a **top-level** `[org_policy_source]` table instead. TOML silently ignores unknown top-level tables (no error, no warning), so following these docs leaves `org_policy_source` at its default `None` and org policy resolution is permanently skipped.
- This caused a real production incident on `ca-merge-warden-prod`: the deployed `config-toml` followed the (wrong) docs, so `resolve_pull_request_config` never attempted to fetch the org policy file — no log lines at all, since `load_org_policy` only logs once it actually runs.
- Adds regression test coverage for `org_policy_source` parsing to both `crates/server/src/config_tests.rs` and `crates/cli/src/config_tests.rs` (previously zero coverage for this field), including a test that pins the exact top-level-vs-nested failure mode so it can't silently regress again.

Production `config-toml` fix is tracked separately (local patch notes, not part of this repo).

## Test plan

- [x] `cargo test -p merge_warden_server -p merge_warden_cli` — 79 passed
- [x] `cargo test -p merge_warden_core` — 852 passed, 1 ignored
- [x] New `org_policy_source` tests specifically verified (6 passed): defaults-to-None, valid nested parse, and the top-level-table-is-ignored regression case, for both server and CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)