### PR TITLE
fix: treat schemaVersion != 1 as an error instead of a silent fallback to defaults

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -2521,10 +2521,48 @@ pub fn validate_repository_scope_patterns(
     Ok(())
 }
 
+/// Validates that a repository-provided configuration declares the supported
+/// schema version.
+///
+/// Logs an `error!` with the repository context and returns
+/// [`ConfigLoadError::UnsupportedSchemaVersion`] when `schema_version != 1`.
+/// Used by both [`load_merge_warden_config`] and [`parse_repo_config`], which
+/// share identical logging/error behaviour for this check.
+///
+/// # Arguments
+/// * `repo_owner` - The name of the user or organisation that owns the repository
+/// * `repo_name` - The name of the repository
+/// * `path` - The path to the configuration file relative to the repository root
+/// * `schema_version` - The `schemaVersion` declared by the parsed configuration
+///
+/// # Returns
+/// * `Ok(())` if `schema_version == 1`
+/// * `Err(ConfigLoadError::UnsupportedSchemaVersion(schema_version))` otherwise
+fn validate_schema_version(
+    repo_owner: &str,
+    repo_name: &str,
+    path: &str,
+    schema_version: u32,
+) -> Result<(), ConfigLoadError> {
+    if schema_version != 1 {
+        error!(
+            repository_owner = repo_owner,
+            repository = repo_name,
+            path = path,
+            config_version = schema_version,
+            "Configuration in repository has an unexpected version. Will not be able to load configuration."
+        );
+
+        return Err(ConfigLoadError::UnsupportedSchemaVersion(schema_version));
+    }
+    Ok(())
+}
+
 /// Loads the merge-warden configuration from the given path.
 //
-/// If the file is missing, malformed, or has an unsupported schema version,
-/// this function returns a default configuration and logs a warning.
+/// If the file is missing, this function returns a default configuration and
+/// logs a warning. If the file has an unsupported schema version, this
+/// function returns an error rather than silently falling back to defaults.
 ///
 /// # Arguments
 /// * `repo_owner` - The name of the user or organisation that owns the repository in which the configuration is stored
@@ -2535,7 +2573,9 @@ pub fn validate_repository_scope_patterns(
 ///
 /// # Returns
 /// * `Ok(RepositoryConfig)` if loaded and valid
-/// * `Err(ConfigLoadError)` if there is a problem
+/// * `Err(ConfigLoadError::UnsupportedSchemaVersion)` if the repository configuration
+///   file specifies a `schemaVersion` other than `1`
+/// * `Err(ConfigLoadError)` if there is any other problem (e.g. malformed TOML)
 pub async fn load_merge_warden_config(
     repo_owner: &str,
     repo_name: &str,
@@ -2560,46 +2600,32 @@ pub async fn load_merge_warden_config(
     };
 
     let mut config: RepositoryProvidedConfig = RepositoryProvidedConfig::default();
-    let mut is_valid_config = true;
     if let Some(content) = potential_content {
         config = toml::from_str(&content)?;
-        if config.schema_version != 1 {
-            error!(
-                repository_owner = repo_owner,
-                repository = repo_name,
-                path = path_relative_to_repository_root,
-                config_version = config.schema_version,
-                "Configuration in repository has an unexpected version. Will not be able to load configuration."
-            );
-
-            // If we can't load the configuration we just pretend it's not there
-            config = RepositoryProvidedConfig::default();
-            is_valid_config = false;
-        }
+        validate_schema_version(
+            repo_owner,
+            repo_name,
+            path_relative_to_repository_root,
+            config.schema_version,
+        )?;
     }
 
-    // Only apply application defaults if we have a valid configuration
-    if is_valid_config {
-        // Build merged policy set: application defaults → repository overrides
-        let app_ps = PolicySet::from_application_defaults(app_defaults);
-        let repo_ps = PolicySet::from_repository_config(&config);
-        let merged_ps = app_ps.merge(&repo_ps);
+    // Build merged policy set: application defaults → repository overrides
+    let app_ps = PolicySet::from_application_defaults(app_defaults);
+    let repo_ps = PolicySet::from_repository_config(&config);
+    let merged_ps = app_ps.merge(&repo_ps);
 
-        // Write merged policies back into config for conversion to CPVRC
-        config.policies.pull_requests.title_policies = merged_ps.title;
-        config.policies.pull_requests.work_item_policies = merged_ps.work_item;
-        config.policies.pull_requests.size_policies = merged_ps.size;
-        config.policies.pull_requests.wip_policies = merged_ps.wip;
-        config.policies.pull_requests.pr_state_policies = merged_ps.pr_state;
-        config.policies.pull_requests.issue_propagation = merged_ps.issue_propagation;
-        config.change_type_labels = Some(merged_ps.change_type_labels);
-        // Write bypass_rules back so to_validation_config uses the merged result
-        // rather than re-merging from the raw BypassRulesConfig sub-rules.
-        config.policies.bypass_rules =
-            Some(BypassRulesConfig::from_merged(&merged_ps.bypass_rules));
-
-        // End of valid config processing
-    }
+    // Write merged policies back into config for conversion to CPVRC
+    config.policies.pull_requests.title_policies = merged_ps.title;
+    config.policies.pull_requests.work_item_policies = merged_ps.work_item;
+    config.policies.pull_requests.size_policies = merged_ps.size;
+    config.policies.pull_requests.wip_policies = merged_ps.wip;
+    config.policies.pull_requests.pr_state_policies = merged_ps.pr_state;
+    config.policies.pull_requests.issue_propagation = merged_ps.issue_propagation;
+    config.change_type_labels = Some(merged_ps.change_type_labels);
+    // Write bypass_rules back so to_validation_config uses the merged result
+    // rather than re-merging from the raw BypassRulesConfig sub-rules.
+    config.policies.bypass_rules = Some(BypassRulesConfig::from_merged(&merged_ps.bypass_rules));
 
     info!(
         enable_title_validation = config.policies.pull_requests.title_policies.required,
@@ -2777,9 +2803,10 @@ pub(crate) async fn load_org_policy(
 /// # Returns
 ///
 /// - `Ok(RepositoryProvidedConfig)` — raw parsed config, or
-///   [`RepositoryProvidedConfig::default`] if the file is absent or has an
-///   unsupported schema version.
+///   [`RepositoryProvidedConfig::default`] if the file is absent.
 /// - `Err(ConfigLoadError::NotFound)` — the config fetcher returned an error.
+/// - `Err(ConfigLoadError::UnsupportedSchemaVersion)` — the repository
+///   configuration file specifies a `schemaVersion` other than `1`.
 /// - `Err(ConfigLoadError::...)` — TOML parse error.
 async fn parse_repo_config(
     repo_owner: &str,
@@ -2810,16 +2837,7 @@ async fn parse_repo_config(
     };
 
     let config: RepositoryProvidedConfig = toml::from_str(&content)?;
-    if config.schema_version != 1 {
-        error!(
-            repository_owner = repo_owner,
-            repository = repo_name,
-            path = path,
-            config_version = config.schema_version,
-            "Configuration in repository has an unexpected version. Will not be able to load configuration."
-        );
-        return Ok(RepositoryProvidedConfig::default());
-    }
+    validate_schema_version(repo_owner, repo_name, path, config.schema_version)?;
 
     Ok(config)
 }
@@ -2862,9 +2880,10 @@ async fn parse_repo_config(
 ///
 /// # Errors
 ///
-/// Repo config load failures (file missing, parse error) are handled internally
-/// by falling back to `PolicySet::default()` for the repo tier, matching the
-/// behaviour previously found in platform handler fallback paths.
+/// Repo config load failures (file missing, parse error, unsupported
+/// `schemaVersion`) are handled internally by falling back to
+/// `PolicySet::default()` for the repo tier, matching the behaviour previously
+/// found in platform handler fallback paths.
 pub async fn resolve_pull_request_config(
     repo_owner: &str,
     repo_name: &str,

--- a/crates/core/src/config_tests.rs
+++ b/crates/core/src/config_tests.rs
@@ -245,6 +245,9 @@ async fn test_load_merge_warden_config_empty_file() {
     );
 }
 
+/// An unsupported `schemaVersion` must cause `load_merge_warden_config` to
+/// return `Err(ConfigLoadError::UnsupportedSchemaVersion(2))` rather than
+/// silently falling back to `Ok(RepositoryProvidedConfig::default())`.
 #[tokio::test]
 async fn test_load_merge_warden_config_invalid_schema() {
     let file_path = "merge-warden.toml";
@@ -260,13 +263,50 @@ pattern = "bar"
     let fetcher = MockFetcher::new(Some(toml.to_string()));
     let app_defaults = ApplicationDefaults::default();
     let result = load_merge_warden_config("a", "b", file_path, &fetcher, &app_defaults).await;
-    // The code returns Ok(default) for unsupported schema version, not an error
+
+    match result {
+        Err(ConfigLoadError::UnsupportedSchemaVersion(version)) => {
+            assert_eq!(
+                version, 2,
+                "Error must carry the actual offending schema version"
+            );
+        }
+        Err(other) => panic!(
+            "Expected Err(ConfigLoadError::UnsupportedSchemaVersion(2)), got Err({:?})",
+            other
+        ),
+        Ok(_) => panic!(
+            "Unsupported schemaVersion must be an error, not a silent fallback to defaults"
+        ),
+    }
+}
+
+/// The `UnsupportedSchemaVersion` error message must be self-contained: it
+/// must name the offending version and tell the operator how to fix it.
+#[tokio::test]
+async fn test_load_merge_warden_config_invalid_schema_error_message_is_actionable() {
+    let file_path = "merge-warden.toml";
+    let toml = r#"schemaVersion = 2
+"#;
+
+    let fetcher = MockFetcher::new(Some(toml.to_string()));
+    let app_defaults = ApplicationDefaults::default();
+    let result = load_merge_warden_config("a", "b", file_path, &fetcher, &app_defaults).await;
+
+    let err = result.expect_err("Unsupported schemaVersion must return an error");
+    let message = err.to_string();
     assert!(
-        result.is_ok(),
-        "Should return Ok(default) for unsupported schema version"
+        message.contains("schemaVersion = 2"),
+        "Error message must contain the offending version number, got: {}",
+        message
     );
-    let config = result.unwrap();
-    assert_eq!(config, RepositoryProvidedConfig::default());
+    assert!(
+        message.to_lowercase().contains("update")
+            && message.to_lowercase().contains("schemaversion")
+            && message.contains('1'),
+        "Error message must contain actionable guidance to update schemaVersion to 1, got: {}",
+        message
+    );
 }
 
 #[tokio::test]
@@ -4772,8 +4812,81 @@ fn test_from_app_enforcement_flags_size_enabled() {
 }
 
 // ============================================================
+// parse_repo_config tests
+// ============================================================
+
+/// An unsupported `schemaVersion` in a repo config must cause the private
+/// `parse_repo_config` helper to return
+/// `Err(ConfigLoadError::UnsupportedSchemaVersion(3))` rather than silently
+/// falling back to `Ok(RepositoryProvidedConfig::default())`.
+#[tokio::test]
+async fn test_parse_repo_config_unsupported_schema_version_returns_error() {
+    let toml = r#"schemaVersion = 3
+
+[policies.pullRequests.prTitle]
+required = true
+pattern = "^SHOULD-NOT-APPLY:"
+"#;
+    let fetcher = MockFetcher::new(Some(toml.to_string()));
+
+    let result = parse_repo_config("owner", "repo", "path", &fetcher).await;
+
+    match result {
+        Err(ConfigLoadError::UnsupportedSchemaVersion(version)) => {
+            assert_eq!(
+                version, 3,
+                "Error must carry the actual offending schema version"
+            );
+        }
+        Err(other) => panic!(
+            "Expected Err(ConfigLoadError::UnsupportedSchemaVersion(3)), got Err({:?})",
+            other
+        ),
+        Ok(_) => panic!(
+            "Unsupported schemaVersion must be an error, not a silent fallback to defaults"
+        ),
+    }
+}
+
+// ============================================================
 // resolve_pull_request_config tests
 // ============================================================
+
+/// When the repo config has an unsupported `schemaVersion`,
+/// `resolve_pull_request_config` must still degrade gracefully to `Ok(...)`
+/// (per its documented fallback-to-defaults behaviour for repo config load
+/// failures), and the bad-schema repo config's policies (e.g. a distinctive
+/// title pattern) must NOT be applied — proving the erroring config was
+/// discarded entirely rather than partially trusted.
+#[tokio::test]
+async fn test_resolve_pull_request_config_unsupported_schema_version_falls_back_to_defaults() {
+    let repo_toml = r#"schemaVersion = 3
+
+[policies.pullRequests.prTitle]
+required = true
+pattern = "^SHOULD-NOT-APPLY:"
+"#;
+    let fetcher = MockFetcher::new(Some(repo_toml.to_string()));
+    let app = ApplicationDefaults::default();
+
+    let result = resolve_pull_request_config("owner", "repo", "path", &fetcher, &app, None)
+        .await
+        .expect(
+            "resolve_pull_request_config must degrade gracefully (Ok) even when \
+             the repo config has an unsupported schema version",
+        );
+
+    assert!(
+        !result.enforce_title_convention,
+        "Policies from a bad-schema-version repo config must not be applied; \
+         title enforcement should remain at its (disabled) default"
+    );
+    assert_ne!(
+        result.title_pattern, "^SHOULD-NOT-APPLY:",
+        "The distinctive title pattern from the bad-schema-version repo config \
+         must not leak into the effective configuration"
+    );
+}
 
 #[tokio::test]
 async fn test_resolve_pull_request_config_no_org_source_no_repo_file() {

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -12,7 +12,11 @@ pub enum ConfigLoadError {
     ParseError(String),
 
     /// The configuration file uses an unsupported schema version
-    #[error("Unsupported schema version: {0}")]
+    #[error(
+        ".github/merge-warden.toml specifies schemaVersion = {0}, which is not supported. \
+         The only supported version is 1. Application defaults are being used to evaluate \
+         this PR. Update schemaVersion to 1 to apply your intended policy."
+    )]
     UnsupportedSchemaVersion(u32),
 
     /// File system I/O error occurred while reading the configuration

--- a/docs/user/reference/per-repo-config.md
+++ b/docs/user/reference/per-repo-config.md
@@ -9,8 +9,9 @@ Place this file at `.github/merge-warden.toml` on the **default branch** of any 
 managed by Merge Warden. The server fetches it via the GitHub API on every webhook event —
 no server restart is needed when you update it.
 
-If the file is absent or malformed, the server falls back to application-level defaults.
-With compiled-in defaults, all validation is disabled.
+If the file is absent, malformed, or specifies an unsupported `schemaVersion`, the server
+falls back to application-level defaults. With compiled-in defaults, all validation is
+disabled.
 
 The top-level `schemaVersion` field is required.
 


### PR DESCRIPTION
## Summary

`.github/merge-warden.toml` with a `schemaVersion` other than `1` was silently
replaced with `RepositoryProvidedConfig::default()`, masking genuine
misconfiguration and behaving inconsistently with malformed TOML (which
already returned `Err(ConfigLoadError::Toml(_))`).

This PR makes an unsupported `schemaVersion` an error, consistent with how
malformed TOML is already handled.

## Changes

- `load_merge_warden_config` and `parse_repo_config`
  (`crates/core/src/config.rs`) now return
  `Err(ConfigLoadError::UnsupportedSchemaVersion(N))` when `schemaVersion != 1`,
  via a new shared private `validate_schema_version` helper (extracted during
  the refactor pass to remove duplicate log/error-construction code).
- `ConfigLoadError::UnsupportedSchemaVersion`'s message
  (`crates/core/src/errors.rs`) is now self-contained: it names the file, the
  bad version, the only supported version, that app defaults are being used,
  and how to fix it.
- `validate_config_content` (used for PR-touches-config validation) is
  **unchanged** — it already returned the correct error.
- `resolve_pull_request_config` is **unchanged** in behaviour: it already
  catches any repo-config load error generically and falls back to
  `PolicySet::default()` for the repo tier with a `warn!` log, so this change
  now also routes the schema-version case through that same, already-tested
  fallback path.
- Updated `test_load_merge_warden_config_invalid_schema` to assert the new
  error (previously asserted `Ok(default)`), and added tests for
  `parse_repo_config` rejection and for propagation/fallback through
  `resolve_pull_request_config`.
- Corrected `docs/user/reference/per-repo-config.md`, which only mentioned
  "absent or malformed" falling back to defaults.

Closes #338

## Pipeline evidence

Run through the full RED → GREEN → REFACTOR → AUDIT + SECURITY → DOCUMENT →
VERIFY pipeline.

**Tests**: `cargo test --workspace --lib` — 980 passed (791 core + 145
developer_platforms + 44 integration-tests), 0 failed. `cargo test -p
merge_warden_core --doc` — 64 passed, 0 failed.

**Audit (QA)**: Reviewed boundary values (0, 1, 2, u32::MAX) against the
`!= 1` equality check — no gaps possible since there's no range logic.
Confirmed `load_org_policy`'s separate schema-version check (different log
fields/message, conditional `Ok(None)`/`Err(OrgPolicyUnavailable)` routing) is
untouched and correctly out of scope. Confirmed no call site outside
`crates/core` calls `load_merge_warden_config`/`parse_repo_config` directly,
so no caller assumed the old always-`Ok` contract. Verdict: **PASS**, no
defects found.

**Security**: Reviewed for information disclosure (error carries only the
`u32` version, no internal state leaked), fail-safe direction (repo tier
still falls back to defaults; org/app tier enforcement still applies), DoS
(O(1) check, no new allocations/loops), format-string injection (thiserror
positional `{0}`, not attacker-controlled), and partial-parse safety (TOML
fully parsed before the schema check; `Err` returned before any use of the
parsed config). Verdict: **PASS**, no blocking findings.

**Refactor**: Extracted `validate_schema_version` to deduplicate identical
log+error blocks between `load_merge_warden_config` and `parse_repo_config`.
Verdict: **CLEAN**.

**Verify**: Independent re-check of all 6 acceptance criteria against actual
code/tests (not just phase notes) — all **PASS**. Confirmed diff scope is
limited to the 4 files listed above.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace --lib`
- [x] `cargo test -p merge_warden_core --doc`
- [x] `cargo clippy` on modified files (0 warnings)
- [x] Manual re-verification of all acceptance criteria from #338
